### PR TITLE
chore: set publish access to public for scoped packages

### DIFF
--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -37,5 +37,8 @@
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "dependencies": {
     "@netlify/remix-runtime": "^1.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/remix-runtime/package.json
+++ b/packages/remix-runtime/package.json
@@ -21,5 +21,8 @@
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "dependencies": {
     "@remix-run/server-runtime": "^1.11.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Description

Sets the publish config to publish scoped packages as public. We did this manually yesterday for the first release, so it shouldn't change, but this ensures these always publish as public.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #29
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes_

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![A hamster with their mouth full](https://www.rd.com/wp-content/uploads/2021/04/GettyImages-1289796719-scaled-e1618347894180.jpg)
