### PR TITLE
chore: update demo site to use renderToReadableStream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "dependencies": {
         "@netlify/edge-functions": "^2.0.0",
         "husky": "^8.0.3",
-        "if-env": "^1.0.4"
+        "if-env": "^1.0.4",
+        "isbot": "^3.6.6"
       },
       "devDependencies": {
         "@netlify/eslint-config-node": "^7.0.1",
@@ -10225,6 +10226,14 @@
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isbot": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.6.tgz",
+      "integrity": "sha512-98aGl1Spbx1led422YFrusDJ4ZutSNOymb2avZ2V4BCCjF3MqAF2k+J2zoaLYahubaFkb+3UyvbVDVlk/Ngrew==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -23203,6 +23212,11 @@
     "isarray": {
       "version": "2.0.5",
       "dev": true
+    },
+    "isbot": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.6.tgz",
+      "integrity": "sha512-98aGl1Spbx1led422YFrusDJ4ZutSNOymb2avZ2V4BCCjF3MqAF2k+J2zoaLYahubaFkb+3UyvbVDVlk/Ngrew=="
     },
     "isexe": {
       "version": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "@netlify/edge-functions": "^2.0.0",
     "husky": "^8.0.3",
-    "if-env": "^1.0.4"
+    "if-env": "^1.0.4",
+    "isbot": "^3.6.6"
   },
   "engines": {
     "node": ">=14"

--- a/packages/edge-demo-site/app/entry.server.tsx
+++ b/packages/edge-demo-site/app/entry.server.tsx
@@ -1,19 +1,28 @@
-import type { EntryContext } from '@remix-run/node'
+import type { EntryContext } from '@remix-run/server-runtime'
 import { RemixServer } from '@remix-run/react'
-import { renderToString } from 'react-dom/server'
+import { renderToReadableStream } from 'react-dom/server'
+import isbot from 'isbot'
 
-export default function handleRequest(
+export default async function handleRequest(
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
   remixContext: EntryContext,
 ) {
-  const markup = renderToString(<RemixServer context={remixContext} url={request.url} />)
+  const body = await renderToReadableStream(<RemixServer context={remixContext} url={request.url} />, {
+    onError() {
+      responseStatusCode = 500
+    },
+  })
+
+  if (isbot(request.headers.get('user-agent'))) {
+    await body.allReady
+  }
 
   responseHeaders.set('Content-Type', 'text/html')
 
-  return new Response('<!DOCTYPE html>' + markup, {
-    headers: responseHeaders,
+  return new Response(body, {
     status: responseStatusCode,
+    headers: responseHeaders,
   })
 }


### PR DESCRIPTION
## Description

## Related Tickets & Documents

Updates the Netlify Edge Functions demo site to use `renderReadableStream`. I checked in with the Remix team after Wes opened #50. Most other templates for edge in the Remix repo use `renderToString` but Jacob recommended to go with `renderReadableStream` instead of `renderToString`.

Thanks again for the feedback @jacob-ebey and @wesbos!

- Related Issues:
  - #16
  - #50
- Closes #

## QA Instructions, Screenshots, Recordings

The deploy preview is all green and when you open the site, it loads up.

![CleanShot 2023-02-23 at 08 06 39](https://user-images.githubusercontent.com/833231/220915107-f46e6633-bb17-473b-ad4d-115eddb4ba60.png)

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

![A hamster doing back flips out of a dish](https://media.giphy.com/media/E0KmHELTpq9pK/giphy.gif)