### PR TITLE
chore: setup netlify config for new monorepo support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "e2e": "cypress open",
     "build:packages": "npm run build -w=packages/remix-runtime -w=packages/remix-adapter -w=packages/remix-edge-adapter",
     "build:packages:watch": "npm run build:watch -w=packages/remix-runtime & npm run build:watch -w=packages/remix-edge-adapter",
-    "build:edge-demo": "npm run build -w=packages/edge-demo-site",
     "build:demo": "npm run build -w=packages/demo-site"
   },
   "repository": {

--- a/packages/edge-demo-site/netlify.toml
+++ b/packages/edge-demo-site/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "npm run build:edge-demo"
+command = "npm run build -w=packages/edge-demo-site"
 publish = "packages/edge-demo-site/public"
 
 [dev]


### PR DESCRIPTION
## Description

Configures the netlify configuration to be in line with the new monorepo support

disregard the build failures for the hydrogen remix site in the PR checks.

<img width="655" alt="CleanShot 2023-07-20 at 16 24 54@2x" src="https://github.com/netlify/remix-compute/assets/833231/0c6cbcaf-e90d-4ae9-9743-5f154a32297a">

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #144

## QA Instructions, Screenshots, Recordings

All the checks should be green. Nothing to test manually.

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
