### PR TITLE
feat(remix-edge-adapter)!: remove future flags from default config

### DIFF
--- a/packages/edge-demo-site/remix.config.js
+++ b/packages/edge-demo-site/remix.config.js
@@ -3,6 +3,15 @@ import { config } from '@netlify/remix-edge-adapter'
 /** @type {import('@remix-run/dev').AppConfig} */
 export default {
   ...config,
+  // See https://remix.run/pages/v2
+  future: {
+    v2_dev: true,
+    v2_errorBoundary: true,
+    v2_headers: true,
+    v2_meta: true,
+    v2_normalizeFormMethod: true,
+    v2_routeConvention: true,
+  },
   // This works out of the box with the Netlify adapter, but you can
   // add your own custom config here if you want to.
   //

--- a/packages/remix-edge-adapter/src/defaultRemixConfig.ts
+++ b/packages/remix-edge-adapter/src/defaultRemixConfig.ts
@@ -1,8 +1,8 @@
 import type { AppConfig } from '@remix-run/dev'
 
 export const config: AppConfig = {
-  server: './server.ts',
   ignoredRouteFiles: ['**/.*'],
+  server: './server.ts',
   serverBuildPath: '.netlify/edge-functions/server.js',
   serverConditions: ['deno', 'worker'],
   serverDependenciesToBundle: 'all',


### PR DESCRIPTION
Adding/removing a future flag would be a breaking change each time, so it's better to keep this in the template itself imo

This would be a breaking change, but we haven't published `@netlify/remix-edge-adapter` v2 yet, so we can just merge this in safely without another breaking change imo

CC/ @nickytonline