### PR TITLE
chore: fixed serverBuildPath for edge demo site for new monorepo support

### DIFF
--- a/packages/edge-demo-site/remix.config.js
+++ b/packages/edge-demo-site/remix.config.js
@@ -8,11 +8,4 @@ module.exports = {
   // add your own custom config here if you want to.
   //
   // See https://remix.run/file-conventions/remix-config
-
-  // The server build path is configured to the root of the monorepo as that's
-  //  where Netlify expects it to be because the base path is the root of the
-  //  monorepo.
-  //
-  // This is not required in user land. It's only for the demo site.
-  serverBuildPath: '../../.netlify/edge-functions/server.js',
 }


### PR DESCRIPTION
## Description

The edge demo site currently builds incorrectly due to the improved monorepo support. The hack I had in place is no longer required.

The Hydrogen demo site and Remix Serverless (demo site) checks will fail for now as #126 is not merged yet and I'm currently fixing the other demo site (remix-serverless).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related PR #126
- Related to issue https://github.com/netlify/pod-ecosystem-frameworks/issues/385

## QA Instructions, Screenshots, Recordings

Everything goes green.

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

<img src="https://media0.giphy.com/media/1SvnHJFEuEH7hp81tF/giphy-downsized-medium.gif"/>
