### PR TITLE
chore: fixed build for remix serverless demo site

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "format:fix:prettier": "prettier --write --cache .",
     "e2e": "cypress open",
     "build:packages": "npm run build -w=packages/remix-runtime -w=packages/remix-adapter -w=packages/remix-edge-adapter",
-    "build:packages:watch": "npm run build:watch -w=packages/remix-runtime & npm run build:watch -w=packages/remix-edge-adapter",
-    "build:demo": "npm run build -w=packages/demo-site"
+    "build:packages:watch": "npm run build:watch -w=packages/remix-runtime & npm run build:watch -w=packages/remix-edge-adapter"
   },
   "repository": {
     "type": "git",

--- a/packages/demo-site/netlify.toml
+++ b/packages/demo-site/netlify.toml
@@ -1,16 +1,16 @@
 [build]
-command = "npm run build:demo"
+command = "npm run build -w packages/demo-site"
 publish = "packages/demo-site/public"
 
 [dev]
 command = "npm run dev -w packages/demo-site"
 
 [[redirects]]
-  from = "/*"
-  to = "/.netlify/functions/server"
-  status = 200
+from = "/*"
+to = "/.netlify/functions/server"
+status = 200
 
 [[headers]]
-  for = "/build/*"
-  [headers.values]
-    "Cache-Control" = "public, max-age=31536000, immutable"
+for = "/build/*"
+[headers.values]
+"Cache-Control" = "public, max-age=31536000, immutable"

--- a/packages/demo-site/remix.config.js
+++ b/packages/demo-site/remix.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   ignoredRouteFiles: ['**/.*'],
   server: process.env.NETLIFY || process.env.NETLIFY_LOCAL ? './server.ts' : undefined,
-  serverBuildPath: '../../.netlify/functions-internal/server.js',
+  serverBuildPath: './.netlify/functions-internal/server.js',
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // publicPath: "/build/",


### PR DESCRIPTION
## Description

Fixes the Remix serverless demo site to support the improved monorepo support. Fixing this will help get the checks in #126 green.

The Hydrogen demo site and Remix edge demo site checks will fail for now as #126 is not merged yet and I'm currently fixing the other demo site in #165.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related PR #126

## QA Instructions, Screenshots, Recordings

The Remix serverless site should build and the E2E tests pass for it.

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**

<img src="https://media1.giphy.com/media/lNUCXNHGH7Gog/giphy.gif"/>