### PR TITLE
Fix import path in function when building on Windows

### DIFF
--- a/packages/remix-adapter/src/plugin.ts
+++ b/packages/remix-adapter/src/plugin.ts
@@ -1,9 +1,13 @@
 import type { Plugin, ResolvedConfig } from 'vite'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { join, relative, sep } from 'node:path'
+import { sep as posixSep } from 'node:path/posix'
 import { version, name } from '../package.json'
+
 const SERVER_ID = 'virtual:netlify-server'
 const RESOLVED_SERVER_ID = `\0${SERVER_ID}`
+
+const toPosixPath = (path: string) => path.split(sep).join(posixSep)
 
 // The virtual module that is the compiled server entrypoint.
 const serverCode = /* js */ `
@@ -11,6 +15,7 @@ import { createRequestHandler } from "@netlify/remix-adapter";
 import * as build from "virtual:remix/server-build";
 export default createRequestHandler({ build });
 `
+
 // This is written to the functions directory. It just re-exports
 // the compiled entrypoint, along with Netlify function config.
 function generateNetlifyFunction(server: string) {
@@ -65,14 +70,16 @@ export function netlifyPlugin(): Plugin {
       resolvedConfig = config
     },
     async writeBundle() {
+      // Write the server entrypoint to the Netlify functions directory
       if (currentCommand === 'build' && isSsr) {
-        // Write the server entrypoint to the Netlify functions directory
-        const functionDir = join(resolvedConfig.root, '.netlify/functions-internal')
-        await mkdir(functionDir, { recursive: true })
-        await writeFile(
-          join(functionDir, 'remix-server.mjs'),
-          generateNetlifyFunction(relative(functionDir, join(resolvedConfig.build.outDir, 'server.js'))),
-        )
+        const functionsDirectory = join(resolvedConfig.root, '.netlify/functions-internal')
+
+        await mkdir(functionsDirectory, { recursive: true })
+
+        const serverPath = join(resolvedConfig.build.outDir, 'server.js')
+        const relativeServerPath = toPosixPath(relative(functionsDirectory, serverPath))
+
+        await writeFile(join(functionsDirectory, 'remix-server.mjs'), generateNetlifyFunction(relativeServerPath))
       }
     },
   }


### PR DESCRIPTION
## Description

On Windows, run `ntl build --offline` on `demos/vite-functions` or `demos/vite-edge` and you will receive some version of the following error:

```
There was an error when loading the '...uildserverserver.js' npm module.
Support for npm modules in edge functions is an experimental feature. 
Refer to https://ntl.fyi/edge-functions-npm for more information.
```

This happens because `export { default } from "..\..\build\server\server.js";` is generated at the top of `demos/vite-functions/.netlify/functions-internal/remix-server.mjs`. The backslashes are then read as escape characters, hence the `'...uildserverserver.js'` with missing characters in the error message.

The fix is to convert the path to posix before generating the file to create the following output instead:
```
export { default } from "../../build/server/server.js";
```

## Related Tickets & Documents

- Related Issue #275 
- Closes #275 

## QA Instructions, Screenshots, Recordings

1. Run `ntl build --offline` on a Windows machine or VM targeting the `vite-functions` or `vite-edge` demo site.

For us to review and ship your PR efficiently, please perform the following steps:

- [x] ~Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.~
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [x] ~Update or add tests (if any source code was changed or added) 🧪~
- [x] ~Update or add documentation (if features were changed or added) 📝~
- [x] Make sure the status checks below are successful ✅