### PR TITLE
fix(remix-edge-adapter): exclude /.netlify paths from edge function

### DIFF
--- a/packages/remix-edge-adapter/src/plugin.ts
+++ b/packages/remix-edge-adapter/src/plugin.ts
@@ -99,7 +99,7 @@ export function netlifyPlugin(): Plugin {
     async writeBundle() {
       // Write the server entrypoint to the Netlify functions directory
       if (currentCommand === 'build' && isSsr) {
-        const exclude: Array<string> = []
+        const exclude: Array<string> = ['/.netlify/*']
         try {
           // Get the client files so we can skip them in the edge function
           const clientDirectory = join(resolvedConfig.build.outDir, '..', 'client')


### PR DESCRIPTION
## Description

Adds a default exclusion so that edge SSR doesn't run for paths under `/.netlify`. I'm going to follow up with an option to add custom paths, but that'll need docs so it will come later.
