### PR TITLE
docs: fix a few readme errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 🎉 Thanks for considering contributing to this project! 🎉
 
 When contributing to this repository, please first discuss the change you wish to make via an
-[issue](https://github.com/netlify/next-runtime/issues/new/choose). Please use the issue templates. They are there to
+[issue](https://github.com/netlify/remix-compute/issues/new/choose). Please use the issue templates. They are there to
 help you and to help the maintainers gather information.
 
 Before working on an issue, ask to be assigned to it. This makes it clear to other potential contributors that someone
@@ -22,17 +22,7 @@ promote a positive and inclusive environment.
 First fork and clone the repository. If you're not sure how to do this, please watch
 [these videos](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
 
-Run:
-
-```bash
-npm install
-```
-
-Make sure everything is correctly setup with:
-
-```bash
-npm test
-```
+See the README for more detailed development instructions.
 
 ## How to write commit messages
 
@@ -46,5 +36,4 @@ Most common commit message prefixes are:
 
 ## Releasing
 
-1. Merge the release PR
-2. Run `npm publish`
+Merge the release PR

--- a/packages/remix-adapter/README.md
+++ b/packages/remix-adapter/README.md
@@ -1,13 +1,4 @@
-# Welcome to Remix!
+## Remix Adapter for Netlify
 
-[Remix](https://remix.run) is a web framework that helps you build better websites with React.
-
-To get started, open a new shell and run:
-
-```sh
-npx create-remix@latest
-```
-
-Then follow the prompts you see in your terminal.
-
-For more information about Remix, [visit remix.run](https://remix.run)!
+The Remix Adapter for Netlify allows you to deploy your [Remix](https://remix.run) app to
+[Netlify Functions](https://docs.netlify.com/functions/overview/).

--- a/packages/remix-edge-adapter/README.md
+++ b/packages/remix-edge-adapter/README.md
@@ -1,4 +1,4 @@
-## Remix Adapter for Netlify
+## Remix Edge Adapter for Netlify
 
-The Remix Adapter for Netlify allows you to deploy your [Remix](https://remix.run) app to
+The Remix Edge Adapter for Netlify allows you to deploy your [Remix](https://remix.run) app to
 [Netlify Edge Functions](https://docs.netlify.com/edge-functions/overview/).


### PR DESCRIPTION
## Description

- `CONTRIBUTING.md` had incorrect dev instructions and copypasta
- the `remix-edge-adapter` README was misleading
- the `remix-adapter` README was a generic Remix project README

These could/should be improved further but I just wanted to fix these glaring issues first.

## Related Tickets & Documents

N/A