### PR TITLE
fix: require node 18 just like remix itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "isbot": "^4.1.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "packageManager": "pnpm@8.15.8"
 }

--- a/packages/remix-adapter/package.json
+++ b/packages/remix-adapter/package.json
@@ -83,7 +83,7 @@
     }
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -83,6 +83,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/remix-runtime/package.json
+++ b/packages/remix-runtime/package.json
@@ -39,6 +39,9 @@
   "peerDependencies": {
     "@remix-run/server-runtime": "^2.8.1"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Description

The remix versions we support already require node 18, so require the same versions here.

## Related Tickets & Documents

Re-do of https://github.com/netlify/remix-compute/pull/212. That PR was stale and couldn't be fixed because we'd changed the status checks in this repo since.

## QA Instructions, Screenshots, Recordings

CI already tests against node 18

- [ ] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
