### PR TITLE
chore: fix duplicate `engines` in `package.json`

### DIFF
--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -84,8 +84,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
Introduced in https://github.com/netlify/remix-compute/pull/212. Not yet released.