### PR TITLE
chore(renovate): configure @remix-run bumps in test fixtures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>netlify/renovate-config"]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,33 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['local>netlify/renovate-config'],
+  // The config we're extending ignores test dirs, but we want to bump some fixture deps
+  ignorePaths: ['**/node_modules/**'],
+  packageRules: [
+    // Since we've enabled Renovate (see above) for fixture sites, adjust the config for these.
+    {
+      matchFileNames: ['tests/**/fixtures/**/package.json'],
+      // If a fixture requires a specific framework version, never bump it.
+      updatePinnedDependencies: false,
+      // Always use `chore:` (since these are test fixtures), to avoid no-op releases.
+      extends: [':semanticCommitTypeAll(chore)'],
+    },
+    {
+      description: 'Stable & unstable Remix bumps in test fixtures',
+      matchFileNames: ['tests/**/fixtures/**/package.json'],
+      // See https://docs.renovatebot.com/presets-monorepo/#monoreporemix.
+      matchSourceUrls: ['https://github.com/remix-run/remix'],
+      // Override the schedule to get immediate PRs.
+      schedule: null,
+      // Apply a unique label so we can trigger additional workflows for these PRs.
+      addLabels: ['bump-framework-in-fixtures'],
+      // Bump even if the release isn't tagged as `latest`.
+      respectLatest: false,
+      // Bump even if it's a pre-release (e.g. 1.2.3-beta.8).
+      ignoreUnstable: false,
+      // Ideally we'd like to disable automerge only for unstable bumps, but this is
+      // difficult (or impossible) to implement so we just disable it entirely.
+      automerge: false,
+    },
+  ],
+}


### PR DESCRIPTION
## Description

This configures Renovate to open bump PRs for Remix dependencies in test fixture sites, including unstable releases. This acts as an automated mechanism to run our test suites against Remix releases as soon as possible.

In a later PR, we'll add a notification mechanism for failures on such PRs.

## Related Tickets & Documents

FRA-525

## QA Instructions, Screenshots, Recordings

I've [validated the config file syntax](https://docs.renovatebot.com/config-validation/).

We've validated most of this already by testing this out in next-runtime-minimal.

We can't really QA this without merging to main.

See also:
- https://docs.renovatebot.com/configuration-options/#respectlatest
- https://docs.renovatebot.com/configuration-options/#ignoreunstable
- https://docs.renovatebot.com/configuration-options/#ignorepaths
- https://github.com/netlify/renovate-config/blob/main/shared.json
- https://docs.renovatebot.com/semantic-commits/
- https://docs.renovatebot.com/configuration-options/#packagerules (especially the "tip" callout)