### PR TITLE
test: add test asserting loader headers can be set on response

### DIFF
--- a/tests/e2e/fixtures/edge-site/app/routes/cached-for-a-year.tsx
+++ b/tests/e2e/fixtures/edge-site/app/routes/cached-for-a-year.tsx
@@ -1,0 +1,30 @@
+import { type HeadersFunction } from "@remix-run/node";
+import { json, useLoaderData } from "@remix-run/react";
+
+export const loader = () => {
+  return json(
+    {
+      message: `Response generated at ${new Date().toISOString()}`,
+    },
+    {
+      headers: {
+        "CDN-Cache-Control": "public, max-age=31536000",
+        "Cache-Tag": "cached-for-a-year-tag",
+      },
+    },
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export default function CachedForAYearDemo() {
+  const { message } = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Cached for a year</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/edge-site/app/routes/headers.tsx
+++ b/tests/e2e/fixtures/edge-site/app/routes/headers.tsx
@@ -1,0 +1,29 @@
+import { type HeadersFunction } from "@remix-run/node";
+import { json, useLoaderData } from "@remix-run/react";
+
+export const loader = () => {
+  return json(
+    {
+      message: "Loader for this page is passing caching headers",
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export default function HeadersDemo() {
+  const { message } = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Headers</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/edge-site/app/routes/middleware-header.tsx
+++ b/tests/e2e/fixtures/edge-site/app/routes/middleware-header.tsx
@@ -1,0 +1,7 @@
+export default function MiddlewareHeader() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Response header added by Edge Middleware</h1>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/edge-site/app/routes/stale-while-revalidate.tsx
+++ b/tests/e2e/fixtures/edge-site/app/routes/stale-while-revalidate.tsx
@@ -1,0 +1,31 @@
+import { type HeadersFunction } from "@remix-run/node";
+import { json, useLoaderData } from "@remix-run/react";
+
+export const loader = () => {
+  return json(
+    {
+      message: `Response generated at ${new Date().toISOString()}`,
+    },
+    {
+      headers: {
+        "CDN-Cache-Control":
+          "public, max-age=10, stale-while-revalidate=31536000",
+        "Cache-Tag": "stale-while-revalidate-tag",
+      },
+    },
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export default function SWRDemo() {
+  const { message } = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Stale-while-revalidate</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/edge-site/netlify/edge-functions/middleware-header.ts
+++ b/tests/e2e/fixtures/edge-site/netlify/edge-functions/middleware-header.ts
@@ -1,0 +1,17 @@
+import type { Config, Context } from "@netlify/edge-functions";
+
+const handler = async (
+  _request: Request,
+  context: Context,
+): Promise<Response> => {
+  const originResponse = await context.next();
+
+  originResponse.headers.set("Foo", "bar");
+  return originResponse;
+};
+
+export default handler;
+
+export const config: Config = {
+  path: "/middleware-header",
+};

--- a/tests/e2e/fixtures/edge-site/netlify/functions/purge-cdn.ts
+++ b/tests/e2e/fixtures/edge-site/netlify/functions/purge-cdn.ts
@@ -1,0 +1,27 @@
+import { type Config, purgeCache } from "@netlify/functions";
+
+const handler = async (request: Request): Promise<Response> => {
+  const url = new URL(request.url);
+  const tagToPurge = url.searchParams.get("tag");
+
+  if (!tagToPurge) {
+    return Response.json(
+      {
+        status: "error",
+        error: 'missing "tag" query parameter',
+      },
+      { status: 400 },
+    );
+  }
+
+  console.log("Purging", tagToPurge);
+  await purgeCache({ tags: [tagToPurge] });
+
+  return new Response(null, { status: 204 });
+};
+
+export default handler;
+
+export const config: Config = {
+  path: "/purge-cdn",
+};

--- a/tests/e2e/fixtures/serverless-site/app/routes/cached-for-a-year.tsx
+++ b/tests/e2e/fixtures/serverless-site/app/routes/cached-for-a-year.tsx
@@ -1,0 +1,30 @@
+import { type HeadersFunction } from "@remix-run/node";
+import { json, useLoaderData } from "@remix-run/react";
+
+export const loader = () => {
+  return json(
+    {
+      message: `Response generated at ${new Date().toISOString()}`,
+    },
+    {
+      headers: {
+        "CDN-Cache-Control": "public, max-age=31536000",
+        "Cache-Tag": "cached-for-a-year-tag",
+      },
+    },
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export default function CachedForAYearDemo() {
+  const { message } = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Cached for a year</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/serverless-site/app/routes/headers.tsx
+++ b/tests/e2e/fixtures/serverless-site/app/routes/headers.tsx
@@ -1,0 +1,29 @@
+import { type HeadersFunction } from "@remix-run/node";
+import { json, useLoaderData } from "@remix-run/react";
+
+export const loader = () => {
+  return json(
+    {
+      message: "Loader for this page is passing caching headers",
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export default function HeadersDemo() {
+  const { message } = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Headers</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/serverless-site/app/routes/middleware-header.tsx
+++ b/tests/e2e/fixtures/serverless-site/app/routes/middleware-header.tsx
@@ -1,0 +1,7 @@
+export default function MiddlewareHeader() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Response header added by Edge Middleware</h1>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/serverless-site/app/routes/stale-while-revalidate.tsx
+++ b/tests/e2e/fixtures/serverless-site/app/routes/stale-while-revalidate.tsx
@@ -1,0 +1,31 @@
+import { type HeadersFunction } from "@remix-run/node";
+import { json, useLoaderData } from "@remix-run/react";
+
+export const loader = () => {
+  return json(
+    {
+      message: `Response generated at ${new Date().toISOString()}`,
+    },
+    {
+      headers: {
+        "CDN-Cache-Control":
+          "public, max-age=10, stale-while-revalidate=31536000",
+        "Cache-Tag": "stale-while-revalidate-tag",
+      },
+    },
+  );
+};
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export default function SWRDemo() {
+  const { message } = useLoaderData<typeof loader>();
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.4" }}>
+      <h1>Stale-while-revalidate</h1>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/tests/e2e/fixtures/serverless-site/netlify/edge-functions/middleware-header.ts
+++ b/tests/e2e/fixtures/serverless-site/netlify/edge-functions/middleware-header.ts
@@ -1,0 +1,17 @@
+import type { Config, Context } from "@netlify/edge-functions";
+
+const handler = async (
+  _request: Request,
+  context: Context,
+): Promise<Response> => {
+  const originResponse = await context.next();
+
+  originResponse.headers.set("Foo", "bar");
+  return originResponse;
+};
+
+export default handler;
+
+export const config: Config = {
+  path: "/middleware-header",
+};

--- a/tests/e2e/fixtures/serverless-site/netlify/functions/purge-cdn.ts
+++ b/tests/e2e/fixtures/serverless-site/netlify/functions/purge-cdn.ts
@@ -1,0 +1,27 @@
+import { type Config, purgeCache } from "@netlify/functions";
+
+const handler = async (request: Request): Promise<Response> => {
+  const url = new URL(request.url);
+  const tagToPurge = url.searchParams.get("tag");
+
+  if (!tagToPurge) {
+    return Response.json(
+      {
+        status: "error",
+        error: 'missing "tag" query parameter',
+      },
+      { status: 400 },
+    );
+  }
+
+  console.log("Purging", tagToPurge);
+  await purgeCache({ tags: [tagToPurge] });
+
+  return new Response(null, { status: 204 });
+};
+
+export default handler;
+
+export const config: Config = {
+  path: "/purge-cdn",
+};

--- a/tests/e2e/user-journeys.spec.ts
+++ b/tests/e2e/user-journeys.spec.ts
@@ -249,4 +249,16 @@ test.describe('User journeys', () => {
       'Third response should not have matching date and time with previous responses',
     ).not.toEqual(responseGeneratedAtText1)
   })
+
+  test('Netlify Edge Middleware can add response headers when using origin SSR', async ({ page, serverlessSite }) => {
+    const response = await page.goto(`${serverlessSite.url}/middleware-header`)
+    expect(response?.status()).toBe(200)
+    expect(response?.headers()['foo']).toBe('bar')
+  })
+
+  test('Netlify Edge Middleware can add response headers when using edge SSR', async ({ page, edgeSite }) => {
+    const response = await page.goto(`${edgeSite.url}/middleware-header`)
+    expect(response?.status()).toBe(200)
+    expect(response?.headers()['foo']).toBe('bar')
+  })
 })

--- a/tests/e2e/user-journeys.spec.ts
+++ b/tests/e2e/user-journeys.spec.ts
@@ -119,4 +119,16 @@ test.describe('User journeys', () => {
       expect(response?.headers()['x-nf-edge-functions']).toBe('server')
     })
   })
+
+  test('response has user-defined Cache-Control header when using origin SSR', async ({ page, serverlessSite }) => {
+    const response = await page.goto(`${serverlessSite.url}/headers`)
+    await expect(page.getByRole('heading', { name: /Headers/i })).toBeVisible()
+    expect(response?.headers()['cache-control']).toBe('public,max-age=3600')
+  })
+
+  test('response has user-defined Cache-Control header when using edge SSR', async ({ page, edgeSite }) => {
+    const response = await page.goto(`${edgeSite.url}/headers`)
+    await expect(page.getByRole('heading', { name: /Headers/i })).toBeVisible()
+    expect(response?.headers()['cache-control']).toBe('public,max-age=3600')
+  })
 })

--- a/tests/e2e/user-journeys.spec.ts
+++ b/tests/e2e/user-journeys.spec.ts
@@ -131,4 +131,74 @@ test.describe('User journeys', () => {
     await expect(page.getByRole('heading', { name: /Headers/i })).toBeVisible()
     expect(response?.headers()['cache-control']).toBe('public,max-age=3600')
   })
+
+  test('user can configure Stale-while-revalidate when using origin SSR', async ({ page, serverlessSite }) => {
+    // attempt to purge cdn cache in case this is a retry
+    await fetch(`${serverlessSite.url}/purge-cdn?tag=stale-while-revalidate-tag`)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
+    await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
+    expect(responseGeneratedAtText2, 'First and second response should have matching date and time').toEqual(
+      responseGeneratedAtText1,
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 6000))
+
+    await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
+    expect(responseGeneratedAtText3, 'First and third response should have matching date and time').toEqual(
+      responseGeneratedAtText1,
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText4 = await page.getByText('Response generated at').textContent()
+    expect(
+      responseGeneratedAtText4,
+      'Fourth response should not have matching date and time with previous responses',
+    ).not.toEqual(responseGeneratedAtText1)
+  })
+
+  test('user can configure Stale-while-revalidate when using edge SSR', async ({ page, edgeSite }) => {
+    // attempt to purge cdn cache in case this is a retry
+    await fetch(`${edgeSite.url}/purge-cdn?tag=stale-while-revalidate-tag`)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await page.goto(`${edgeSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
+    await page.goto(`${edgeSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
+    expect(responseGeneratedAtText2, 'First and second response should have matching date and time').toEqual(
+      responseGeneratedAtText1,
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 6000))
+
+    await page.goto(`${edgeSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
+    expect(responseGeneratedAtText3, 'First and third response should have matching date and time').toEqual(
+      responseGeneratedAtText1,
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await page.goto(`${edgeSite.url}/stale-while-revalidate`)
+    const responseGeneratedAtText4 = await page.getByText('Response generated at').textContent()
+    expect(
+      responseGeneratedAtText4,
+      'Fourth response should not have matching date and time with previous responses',
+    ).not.toEqual(responseGeneratedAtText1)
+  })
 })

--- a/tests/e2e/user-journeys.spec.ts
+++ b/tests/e2e/user-journeys.spec.ts
@@ -133,15 +133,10 @@ test.describe('User journeys', () => {
   })
 
   test('user can configure Stale-while-revalidate when using origin SSR', async ({ page, serverlessSite }) => {
-    // attempt to purge cdn cache in case this is a retry
-    await fetch(`${serverlessSite.url}/purge-cdn?tag=stale-while-revalidate-tag`)
-
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
     await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
 
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await page.waitForTimeout(5000)
 
     await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
@@ -149,7 +144,7 @@ test.describe('User journeys', () => {
       responseGeneratedAtText1,
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 6000))
+    await page.waitForTimeout(6000)
 
     await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
@@ -157,7 +152,7 @@ test.describe('User journeys', () => {
       responseGeneratedAtText1,
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await page.waitForTimeout(1000)
 
     await page.goto(`${serverlessSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText4 = await page.getByText('Response generated at').textContent()
@@ -168,15 +163,10 @@ test.describe('User journeys', () => {
   })
 
   test('user can configure Stale-while-revalidate when using edge SSR', async ({ page, edgeSite }) => {
-    // attempt to purge cdn cache in case this is a retry
-    await fetch(`${edgeSite.url}/purge-cdn?tag=stale-while-revalidate-tag`)
-
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
     await page.goto(`${edgeSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
 
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await page.waitForTimeout(5000)
 
     await page.goto(`${edgeSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
@@ -184,7 +174,7 @@ test.describe('User journeys', () => {
       responseGeneratedAtText1,
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 6000))
+    await page.waitForTimeout(6000)
 
     await page.goto(`${edgeSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
@@ -192,7 +182,7 @@ test.describe('User journeys', () => {
       responseGeneratedAtText1,
     )
 
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await page.waitForTimeout(1000)
 
     await page.goto(`${edgeSite.url}/stale-while-revalidate`)
     const responseGeneratedAtText4 = await page.getByText('Response generated at').textContent()
@@ -206,7 +196,7 @@ test.describe('User journeys', () => {
     await page.goto(`${serverlessSite.url}/cached-for-a-year`)
     const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
 
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await page.waitForTimeout(5000)
 
     await page.goto(`${serverlessSite.url}/cached-for-a-year`)
     const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
@@ -216,7 +206,7 @@ test.describe('User journeys', () => {
 
     await fetch(`${serverlessSite.url}/purge-cdn?tag=cached-for-a-year-tag`)
 
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await page.waitForTimeout(1000)
 
     await page.goto(`${serverlessSite.url}/cached-for-a-year`)
     const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
@@ -230,7 +220,7 @@ test.describe('User journeys', () => {
     await page.goto(`${edgeSite.url}/cached-for-a-year`)
     const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
 
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await page.waitForTimeout(5000)
 
     await page.goto(`${edgeSite.url}/cached-for-a-year`)
     const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
@@ -240,7 +230,7 @@ test.describe('User journeys', () => {
 
     await fetch(`${edgeSite.url}/purge-cdn?tag=cached-for-a-year-tag`)
 
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await page.waitForTimeout(1000)
 
     await page.goto(`${edgeSite.url}/cached-for-a-year`)
     const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()

--- a/tests/e2e/user-journeys.spec.ts
+++ b/tests/e2e/user-journeys.spec.ts
@@ -201,4 +201,52 @@ test.describe('User journeys', () => {
       'Fourth response should not have matching date and time with previous responses',
     ).not.toEqual(responseGeneratedAtText1)
   })
+
+  test('user can on-demand purge response cached on CDN when using origin SSR', async ({ page, serverlessSite }) => {
+    await page.goto(`${serverlessSite.url}/cached-for-a-year`)
+    const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
+    await page.goto(`${serverlessSite.url}/cached-for-a-year`)
+    const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
+    expect(responseGeneratedAtText2, 'First and second response should have matching date and time').toEqual(
+      responseGeneratedAtText1,
+    )
+
+    await fetch(`${serverlessSite.url}/purge-cdn?tag=cached-for-a-year-tag`)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await page.goto(`${serverlessSite.url}/cached-for-a-year`)
+    const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
+    expect(
+      responseGeneratedAtText3,
+      'Third response should not have matching date and time with previous responses',
+    ).not.toEqual(responseGeneratedAtText1)
+  })
+
+  test('user can on-demand purge response cached on CDN when using edge SSR', async ({ page, edgeSite }) => {
+    await page.goto(`${edgeSite.url}/cached-for-a-year`)
+    const responseGeneratedAtText1 = await page.getByText('Response generated at').textContent()
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
+    await page.goto(`${edgeSite.url}/cached-for-a-year`)
+    const responseGeneratedAtText2 = await page.getByText('Response generated at').textContent()
+    expect(responseGeneratedAtText2, 'First and second response should have matching date and time').toEqual(
+      responseGeneratedAtText1,
+    )
+
+    await fetch(`${edgeSite.url}/purge-cdn?tag=cached-for-a-year-tag`)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await page.goto(`${edgeSite.url}/cached-for-a-year`)
+    const responseGeneratedAtText3 = await page.getByText('Response generated at').textContent()
+    expect(
+      responseGeneratedAtText3,
+      'Third response should not have matching date and time with previous responses',
+    ).not.toEqual(responseGeneratedAtText1)
+  })
 })


### PR DESCRIPTION
## Description

This adds user journey tests related to caching

## Related Tickets & Documents

Closes https://linear.app/netlify/issue/FRA-509/implement-remix-user-journey-tests-related-to-caching


Given | When | Then | Note
-- | -- | -- | --
loader returns custom Cache-Control: foo response header for A | load A | serves response with Cache-Control: foo header | Implemented
configured middleware via framework which sets custom Foo: bar response header for A | load A | serves response with Foo: bar header | Not applicable / not implemented
user-defined Netlify Edge Function middleware which sets custom Foo: bar response header for A | load A | serves response with Foo: bar header | Implemented
configured SWR=90 for A | load Await 5sload Await 86sload Await 5sload A* requires sticky CDN node targeting | serves response from origin function (v1)serves pre-rendered response from CDN edge (v1)serves pre-rendered response from CDN edge (v1)serves pre-rendered response from CDN edge (v2) | Implemented
configured SWR=90 for A | load Await 5sload Ainvalidate A on demandload A | serves response from origin function (v1)serves pre-rendered response from CDN edge (v1)serves response from origin (v2) | Implemented

Implemented tests were implemented for Vite Serverless and Vite Edge cases

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes_

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅
