### PR TITLE
chore: deflake user journey tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,11 @@ jobs:
           node-version: '18'
 
       - run: corepack enable
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          # Should match the `DENO_VERSION_RANGE` from https://github.com/netlify/edge-bundler/blob/main/node/bridge.ts#L17
+          deno-version: v1.37.0
       - run: pnpm install
 
       - name: Install Playwright Browsers

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   testDir: './tests/e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
-  workers: 4,
+  workers: 1,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */


### PR DESCRIPTION
## Description

Recently added User Journey / e2e tests proved to be quite flaky, so this attempts to remove at least some flakiness
 - Seems like on-demand Deno installation that happen when using CLI (or probably `@netlify/build`) is quite flaky, so we will preinstall it in Github Action
 - Seems like running single worker is more beneficial than trying to parallelize work into 4 workers - https://github.com/netlify/remix-compute/pull/375#discussion_r1628015921 has a bit more context on that

## Related Tickets & Documents

- Closes https://linear.app/netlify/issue/FRA-509/implement-remix-user-journey-tests-related-to-caching

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes_

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/remix-compute/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
