### PR TITLE
ci(kodiak): fix conflict between Kodiak and Renovate

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,8 +1,4 @@
 version = 1
 
-[merge.automerge_dependencies]
-versions = ["minor", "patch"]
-usernames = ["renovate"]
-
 [approve]
 auto_approve_usernames = ["renovate"]


### PR DESCRIPTION
## Description

We have specific configuration for what Renovate should automerge, but then a separate Kodiak config that automerges based on another set of rules.

We only want to use Kodiak to auto-approve Renovate PRs.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

We should see it stop merging unstable remix bump PRs

**A picture of a cute animal (not mandatory, but encouraged)**
