### PR TITLE
ci: fix release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,12 @@ jobs:
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
+      - name: Install Deno
+        uses: denoland/setup-deno@v1
+        with:
+          # Should satisfy the `DENO_VERSION_RANGE` from https://github.com/netlify/edge-bundler/blob/main/node/bridge.ts#L17
+          deno-version: v1
+        if: ${{ steps.release.outputs.releases_created }}
       - run: corepack enable
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
We recently added a post-install script that requires Deno, so we need to install it in this workflow.