### PR TITLE
fix(deps): remove unintentional user dependency on `deno`

### DIFF
--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -40,9 +40,10 @@
   ],
   "scripts": {
     "prepack": "pnpm run build",
-    "postinstall": "deno types > deno.d.ts",
-    "build": "tsup-node src/index.ts src/vite/plugin.ts --format esm,cjs --dts --target node16 --clean",
-    "build:watch": "pnpm run build --watch"
+    "build": "pnpm run build:src && pnpm run build:types",
+    "build:src": "tsup-node src/index.ts src/vite/plugin.ts --format esm,cjs --dts --target node16 --clean",
+    "build:types": "deno types > deno.d.ts",
+    "build:watch": "pnpm run build:src --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

We accidentally introduced a dependency on `deno` at site build time by including a command that uses `deno` in a post-install hook.

The intent was to run it before typechecking and before publishing, so including it in the build command instead works as well but won't run for users.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Delete `packages/remix-edge-adapter/{dist,deno.d.ts}`, run `pnpm run build:packages`, inspect output, run `pnpm run typecheck`. All looks good.