### PR TITLE
fix: stop re-exporting exports removed in remix@2.12.0

### DIFF
--- a/packages/remix-adapter/package.json
+++ b/packages/remix-adapter/package.json
@@ -58,13 +58,13 @@
   },
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "dependencies": {
-    "@remix-run/node": "^2.9.2",
+    "@remix-run/node": "^2.12.0",
     "isbot": "^5.0.0"
   },
   "devDependencies": {
     "@netlify/functions": "^2.8.1",
-    "@remix-run/dev": "^2.9.2",
-    "@remix-run/react": "^2.9.2",
+    "@remix-run/dev": "^2.12.0",
+    "@remix-run/react": "^2.12.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "lambda-tester": "^4.0.1",

--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -65,7 +65,7 @@
     "isbot": "^5.0.0"
   },
   "devDependencies": {
-    "@remix-run/react": "^2.9.2",
+    "@remix-run/react": "^2.12.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "react": "^18.2.0",

--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -61,7 +61,7 @@
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "dependencies": {
     "@netlify/remix-runtime": "2.3.0",
-    "@remix-run/dev": "^2.9.2",
+    "@remix-run/dev": "^2.12.0",
     "isbot": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/remix-runtime/package.json
+++ b/packages/remix-runtime/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "devDependencies": {
-    "@remix-run/server-runtime": "^2.9.2",
+    "@remix-run/server-runtime": "^2.12.0",
     "tsup": "^8.0.2"
   },
   "peerDependencies": {

--- a/packages/remix-runtime/src/index.ts
+++ b/packages/remix-runtime/src/index.ts
@@ -26,12 +26,13 @@ export {
   unstable_composeUploadHandlers,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,
-  unstable_defineLoader,
-  unstable_defineAction,
   unstable_setDevServerHooks,
   UNSAFE_SingleFetchRedirectSymbol,
 } from '@remix-run/server-runtime'
 
+// TODO(serhalp) The docs say we should simply re-export all types from `/reexport`:
+// https://github.com/remix-run/remix/tree/main/packages/remix-server-runtime#readme.
+// Let's do that, but carefully verify whether this adds or removes any exports first.
 export type {
   ActionFunction,
   ActionFunctionArgs,
@@ -78,9 +79,6 @@ export type {
   UnsignFunction,
   UploadHandlerPart,
   UploadHandler,
-  unstable_Loader,
-  unstable_Action,
-  unstable_Serialize,
   UNSAFE_SingleFetchResults,
   UNSAFE_SingleFetchResult,
 } from '@remix-run/server-runtime'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,8 +311,8 @@ importers:
   packages/remix-adapter:
     dependencies:
       '@remix-run/node':
-        specifier: ^2.9.2
-        version: 2.11.1(typescript@5.4.5)
+        specifier: ^2.12.0
+        version: 2.12.0(typescript@5.4.5)
       isbot:
         specifier: ^5.0.0
         version: 5.1.12
@@ -321,11 +321,11 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       '@remix-run/dev':
-        specifier: ^2.9.2
-        version: 2.11.1(@remix-run/react@2.11.1)(@remix-run/serve@2.11.1)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5)
+        specifier: ^2.12.0
+        version: 2.12.0(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5)
       '@remix-run/react':
-        specifier: ^2.9.2
-        version: 2.11.1(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+        specifier: ^2.12.0
+        version: 2.12.0(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.0.27
         version: 18.3.3
@@ -354,8 +354,8 @@ importers:
         specifier: 2.3.0
         version: link:../remix-runtime
       '@remix-run/dev':
-        specifier: ^2.9.2
-        version: 2.11.1(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5)
+        specifier: ^2.12.0
+        version: 2.12.0(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5)
       isbot:
         specifier: ^5.0.0
         version: 5.1.12
@@ -455,7 +455,7 @@ packages:
       '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
       convert-source-map: 2.0.0
-      debug: 4.3.6(supports-color@9.4.0)
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3166,13 +3166,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@remix-run/dev@2.11.1(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5):
-    resolution: {integrity: sha512-zYiyKVjm+wBr1+P+W3psP79cuwh1qlQCbcwJhYVD6p6DJURTiotDxjnw/WtGgYrhNTuxyJ21dhRv4gHzLV/4Hg==}
+  /@remix-run/dev@2.12.0(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5):
+    resolution: {integrity: sha512-/87YQORdlJg5YChd7nVBM/hRXHZA4GfUjhKbZyNrh03bazCQBF+6EsXbzpJ6cCFOpZgecsN0Xv648Qw0VuJjwg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
-      '@remix-run/react': ^2.11.1
-      '@remix-run/serve': ^2.11.1
+      '@remix-run/react': ^2.12.0
+      '@remix-run/serve': ^2.12.0
       typescript: ^5.1.0
       vite: ^5.1.0
       wrangler: ^3.28.2
@@ -3196,10 +3196,10 @@ packages:
       '@babel/types': 7.25.2
       '@mdx-js/mdx': 2.3.0
       '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.11.1(typescript@5.4.5)
+      '@remix-run/node': 2.12.0(typescript@5.4.5)
       '@remix-run/react': 2.12.0(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
-      '@remix-run/router': 1.19.0
-      '@remix-run/server-runtime': 2.11.1(typescript@5.4.5)
+      '@remix-run/router': 1.19.2
+      '@remix-run/server-runtime': 2.12.0(typescript@5.4.5)
       '@types/mdx': 2.0.13
       '@vanilla-extract/integration': 6.5.0(@types/node@20.16.5)
       arg: 5.0.2
@@ -3257,7 +3257,6 @@ packages:
       - terser
       - ts-node
       - utf-8-validate
-    dev: false
 
   /@remix-run/eslint-config@2.11.1(eslint@8.57.0)(react@18.3.1)(typescript@5.4.5):
     resolution: {integrity: sha512-Qzrww4D1Bfl+Z+qYprOc43/iEl/QS1i+kTo0XickLMEiTsal0qEeIt9Zod6alO0DvLEm6ixUPQDHKcn2trwLtA==}
@@ -3319,6 +3318,24 @@ packages:
         optional: true
     dependencies:
       '@remix-run/server-runtime': 2.11.1(typescript@5.4.5)
+      '@remix-run/web-fetch': 4.4.2
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie-signature: 1.2.1
+      source-map-support: 0.5.21
+      stream-slice: 0.1.2
+      typescript: 5.4.5
+      undici: 6.19.7
+
+  /@remix-run/node@2.12.0(typescript@5.4.5):
+    resolution: {integrity: sha512-83Jaoc6gpSuD4e6rCk7N5ZHAXNmDw4fJC+kPeDCsd6+wLtTLSi7u9Zo9/Q7moLZ3oyH+aR+LGdkxLULYv+Q6Og==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/server-runtime': 2.12.0(typescript@5.4.5)
       '@remix-run/web-fetch': 4.4.2
       '@web3-storage/multipart-parser': 1.0.0
       cookie-signature: 1.2.1
@@ -6216,7 +6233,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /decache@4.6.2:
     resolution: {integrity: sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,14 +355,14 @@ importers:
         version: link:../remix-runtime
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.11.1(@remix-run/react@2.11.1)(@remix-run/serve@2.11.1)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5)
+        version: 2.11.1(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5)
       isbot:
         specifier: ^5.0.0
         version: 5.1.12
     devDependencies:
       '@remix-run/react':
-        specifier: ^2.9.2
-        version: 2.11.1(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+        specifier: ^2.12.0
+        version: 2.12.0(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.0.27
         version: 18.3.3
@@ -385,8 +385,8 @@ importers:
   packages/remix-runtime:
     devDependencies:
       '@remix-run/server-runtime':
-        specifier: ^2.9.2
-        version: 2.11.1(typescript@5.4.5)
+        specifier: ^2.12.0
+        version: 2.12.0(typescript@5.4.5)
       tsup:
         specifier: ^8.0.2
         version: 8.1.0(postcss@8.4.41)(ts-node@10.9.2)(typescript@5.4.5)
@@ -3164,6 +3164,100 @@ packages:
       - terser
       - ts-node
       - utf-8-validate
+    dev: true
+
+  /@remix-run/dev@2.11.1(@remix-run/react@2.12.0)(@types/node@20.16.5)(ts-node@10.9.2)(typescript@5.4.5)(vite@5.3.5):
+    resolution: {integrity: sha512-zYiyKVjm+wBr1+P+W3psP79cuwh1qlQCbcwJhYVD6p6DJURTiotDxjnw/WtGgYrhNTuxyJ21dhRv4gHzLV/4Hg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@remix-run/react': ^2.11.1
+      '@remix-run/serve': ^2.11.1
+      typescript: ^5.1.0
+      vite: ^5.1.0
+      wrangler: ^3.28.2
+    peerDependenciesMeta:
+      '@remix-run/serve':
+        optional: true
+      typescript:
+        optional: true
+      vite:
+        optional: true
+      wrangler:
+        optional: true
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/generator': 7.25.0
+      '@babel/parser': 7.25.3
+      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.25.2)
+      '@babel/traverse': 7.25.3
+      '@babel/types': 7.25.2
+      '@mdx-js/mdx': 2.3.0
+      '@npmcli/package-json': 4.0.1
+      '@remix-run/node': 2.11.1(typescript@5.4.5)
+      '@remix-run/react': 2.12.0(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+      '@remix-run/router': 1.19.0
+      '@remix-run/server-runtime': 2.11.1(typescript@5.4.5)
+      '@types/mdx': 2.0.13
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.16.5)
+      arg: 5.0.2
+      cacache: 17.1.4
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      cross-spawn: 7.0.3
+      dotenv: 16.4.5
+      es-module-lexer: 1.5.4
+      esbuild: 0.17.6
+      esbuild-plugins-node-modules-polyfill: 1.6.4(esbuild@0.17.6)
+      execa: 5.1.1
+      exit-hook: 2.2.1
+      express: 4.19.2
+      fs-extra: 10.1.0
+      get-port: 5.1.1
+      gunzip-maybe: 1.4.2
+      jsesc: 3.0.2
+      json5: 2.2.3
+      lodash: 4.17.21
+      lodash.debounce: 4.0.8
+      minimatch: 9.0.5
+      ora: 5.4.1
+      picocolors: 1.0.1
+      picomatch: 2.3.1
+      pidtree: 0.6.0
+      postcss: 8.4.41
+      postcss-discard-duplicates: 5.1.0(postcss@8.4.41)
+      postcss-load-config: 4.0.2(postcss@8.4.41)(ts-node@10.9.2)
+      postcss-modules: 6.0.0(postcss@8.4.41)
+      prettier: 2.8.8
+      pretty-ms: 7.0.1
+      react-refresh: 0.14.2
+      remark-frontmatter: 4.0.1
+      remark-mdx-frontmatter: 1.1.1
+      semver: 7.6.3
+      set-cookie-parser: 2.7.0
+      tar-fs: 2.1.1
+      tsconfig-paths: 4.2.0
+      typescript: 5.4.5
+      vite: 5.3.5(@types/node@20.16.5)
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - bluebird
+      - bufferutil
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - ts-node
+      - utf-8-validate
+    dev: false
 
   /@remix-run/eslint-config@2.11.1(eslint@8.57.0)(react@18.3.1)(typescript@5.4.5):
     resolution: {integrity: sha512-Qzrww4D1Bfl+Z+qYprOc43/iEl/QS1i+kTo0XickLMEiTsal0qEeIt9Zod6alO0DvLEm6ixUPQDHKcn2trwLtA==}
@@ -3185,7 +3279,7 @@ packages:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.16.1)(eslint@8.57.0)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
@@ -3253,8 +3347,32 @@ packages:
       turbo-stream: 2.2.0
       typescript: 5.4.5
 
+  /@remix-run/react@2.12.0(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5):
+    resolution: {integrity: sha512-Y109tI37Icr0BSU8sWSo8jDPkXaErJ/e1h0fkPvq6LZ0DrlcmHWBxzWJKID431I/KJvhVvBgVCuDamZTRVOZ5Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/router': 1.19.2
+      '@remix-run/server-runtime': 2.12.0(typescript@5.4.5)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.26.2(react@18.3.1)
+      react-router-dom: 6.26.2(react-dom@18.3.1)(react@18.3.1)
+      turbo-stream: 2.4.0
+      typescript: 5.4.5
+
   /@remix-run/router@1.19.0:
     resolution: {integrity: sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==}
+    engines: {node: '>=14.0.0'}
+
+  /@remix-run/router@1.19.2:
+    resolution: {integrity: sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==}
     engines: {node: '>=14.0.0'}
 
   /@remix-run/serve@2.11.1(typescript@5.4.5):
@@ -3290,6 +3408,24 @@ packages:
       set-cookie-parser: 2.7.0
       source-map: 0.7.4
       turbo-stream: 2.2.0
+      typescript: 5.4.5
+
+  /@remix-run/server-runtime@2.12.0(typescript@5.4.5):
+    resolution: {integrity: sha512-o9ukOr3XKmyY8UufTrDdkgD3fiy+z+f4qEzvCQnvC0+EasCyN9hb1Vbui6Koo/5HKvahC4Ga8RcWyvhykKrG3g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/router': 1.19.2
+      '@types/cookie': 0.6.0
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie: 0.6.0
+      set-cookie-parser: 2.7.0
+      source-map: 0.7.4
+      turbo-stream: 2.4.0
       typescript: 5.4.5
 
   /@remix-run/web-blob@3.1.0:
@@ -6911,7 +7047,7 @@ packages:
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.16.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -7024,7 +7160,36 @@ packages:
       debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.1(@typescript-eslint/parser@7.16.1)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+    resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.4.5)
+      debug: 3.2.7
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7157,6 +7322,41 @@ packages:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.16.1)(eslint@8.57.0):
+    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.4.5)
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.16.1)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -12701,6 +12901,18 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.26.0(react@18.3.1)
 
+  /react-router-dom@6.26.2(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.19.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.26.2(react@18.3.1)
+
   /react-router@6.26.0(react@18.3.1):
     resolution: {integrity: sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==}
     engines: {node: '>=14.0.0'}
@@ -12708,6 +12920,15 @@ packages:
       react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.19.0
+      react: 18.3.1
+
+  /react-router@6.26.2(react@18.3.1):
+    resolution: {integrity: sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.19.2
       react: 18.3.1
 
   /react@18.3.1:
@@ -14323,6 +14544,9 @@ packages:
 
   /turbo-stream@2.2.0:
     resolution: {integrity: sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g==}
+
+  /turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   /type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}


### PR DESCRIPTION
## Description

Some "unstable" functions and types were removed in https://github.com/remix-run/remix/pull/9893.

Since they were clearly named `unstable_` and Remix doesn't require major releases for changes to these, we'll do the same thing here.

We should probably just not export any `unstable_`e xports. Remix doesn't actually require that server runtime implementations export these: https://github.com/remix-run/remix/tree/main/packages/remix-server-runtime#readme.

## Related Tickets & Documents

Closes #458, which actually affects both Remix and Hydrogen.

## QA Instructions, Screenshots, Recordings

N/A - just bumps remix dev dep and fixes type errors