### PR TITLE
fix(deps): support and test against Vite 6

### DIFF
--- a/demos/vite-edge/package.json
+++ b/demos/vite-edge/package.json
@@ -11,17 +11,18 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@netlify/remix-edge-adapter": "^3.4.2",
-    "@netlify/remix-runtime": "^2.3.1",
-    "@remix-run/react": "^2.9.2",
-    "@remix-run/serve": "^2.9.2",
+    "@netlify/remix-edge-adapter": "workspace:*",
+    "@netlify/remix-runtime": "workspace:*",
+    "@remix-run/node": "^2.16.4",
+    "@remix-run/react": "^2.16.4",
+    "@remix-run/serve": "^2.16.4",
     "isbot": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@netlify/functions": "^3.0.0",
-    "@remix-run/dev": "^2.9.2",
+    "@remix-run/dev": "^2.16.4",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -33,8 +34,8 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.6",
-    "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite": "^6.2.5",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/demos/vite-functions/package.json
+++ b/demos/vite-functions/package.json
@@ -11,16 +11,16 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@netlify/remix-adapter": "^2.6.0",
-    "@remix-run/node": "^2.9.2",
-    "@remix-run/react": "^2.9.2",
-    "@remix-run/serve": "^2.9.2",
+    "@netlify/remix-adapter": "workspace:*",
+    "@remix-run/node": "^2.16.4",
+    "@remix-run/react": "^2.16.4",
+    "@remix-run/serve": "^2.16.4",
     "isbot": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.9.2",
+    "@remix-run/dev": "^2.16.4",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -32,8 +32,8 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.6",
-    "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite": "^6.2.5",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/remix-adapter/package.json
+++ b/packages/remix-adapter/package.json
@@ -58,19 +58,19 @@
   },
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "dependencies": {
-    "@remix-run/node": "^2.12.0",
+    "@remix-run/node": "^2.16.4",
     "isbot": "^5.0.0"
   },
   "devDependencies": {
     "@netlify/functions": "^3.0.0",
-    "@remix-run/dev": "^2.12.0",
-    "@remix-run/react": "^2.12.0",
+    "@remix-run/dev": "^2.16.4",
+    "@remix-run/react": "^2.16.4",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsup": "^8.0.2",
-    "vite": "^5.4.11"
+    "vite": "^6.2.5"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"

--- a/packages/remix-adapter/package.json
+++ b/packages/remix-adapter/package.json
@@ -73,7 +73,7 @@
     "vite": "^5.4.11"
   },
   "peerDependencies": {
-    "vite": "^5.0.0"
+    "vite": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -61,17 +61,18 @@
   "homepage": "https://github.com/netlify/remix-compute#readme",
   "dependencies": {
     "@netlify/remix-runtime": "2.3.1",
-    "@remix-run/dev": "^2.12.0",
+    "@remix-run/dev": "^2.16.4",
+    "@remix-run/node": "^2.16.4",
     "isbot": "^5.0.0"
   },
   "devDependencies": {
-    "@remix-run/react": "^2.12.0",
+    "@remix-run/react": "^2.16.4",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsup": "^8.0.2",
-    "vite": "^5.1.3"
+    "vite": "^6.2.5"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"

--- a/packages/remix-edge-adapter/package.json
+++ b/packages/remix-edge-adapter/package.json
@@ -74,7 +74,7 @@
     "vite": "^5.1.3"
   },
   "peerDependencies": {
-    "vite": "^5.0.0"
+    "vite": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/packages/vite-plugin-react-router/package.json
+++ b/packages/vite-plugin-react-router/package.json
@@ -56,7 +56,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tsup": "^8.0.2",
-    "vite": "^5.4.11"
+    "vite": "^6.2.5"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,10 +89,10 @@ importers:
         version: 2.15.3
       '@remix-run/node':
         specifier: ^2.9.2
-        version: 2.15.3(typescript@5.7.3)
+        version: 2.16.4(typescript@5.7.3)
       '@remix-run/react':
         specifier: ^2.9.2
-        version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+        version: 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -102,13 +102,13 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)
+        version: 2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5)
       '@remix-run/eslint-config':
         specifier: ^2.9.2
         version: 2.15.3(eslint@8.57.1)(react@18.3.1)(typescript@5.7.3)
       '@remix-run/serve':
         specifier: ^2.9.2
-        version: 2.15.3(typescript@5.7.3)
+        version: 2.16.4(typescript@5.7.3)
       '@types/react':
         specifier: ^18.0.27
         version: 18.3.20
@@ -138,7 +138,7 @@ importers:
         version: 2.15.3
       '@remix-run/react':
         specifier: ^2.9.2
-        version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+        version: 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -151,13 +151,13 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)
+        version: 2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5)
       '@remix-run/eslint-config':
         specifier: ^2.9.2
         version: 2.15.3(eslint@8.57.1)(react@18.3.1)(typescript@5.7.3)
       '@remix-run/serve':
         specifier: ^2.9.2
-        version: 2.15.3(typescript@5.7.3)
+        version: 2.16.4(typescript@5.7.3)
       '@types/react':
         specifier: ^18.0.27
         version: 18.3.20
@@ -389,7 +389,7 @@ importers:
     devDependencies:
       '@remix-run/server-runtime':
         specifier: ^2.12.0
-        version: 2.15.3(typescript@5.7.3)
+        version: 2.16.4(typescript@5.7.3)
       tsup:
         specifier: ^8.0.2
         version: 8.4.0(postcss@8.5.3)(typescript@5.7.3)
@@ -2350,7 +2350,7 @@ packages:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       tar: 6.2.1
     transitivePeerDependencies:
       - encoding
@@ -2409,7 +2409,7 @@ packages:
       find-up: 6.3.0
       minimatch: 9.0.5
       read-pkg: 7.1.0
-      semver: 7.6.3
+      semver: 7.7.1
       yaml: 2.7.0
       yargs: 17.7.2
     dev: true
@@ -2440,7 +2440,7 @@ packages:
       '@opentelemetry/api': 1.8.0
       '@sindresorhus/slugify': 2.2.1
       ansi-escapes: 6.2.1
-      chalk: 5.3.0
+      chalk: 5.4.1
       clean-stack: 4.2.0
       execa: 6.1.0
       fdir: 6.4.3(picomatch@4.0.2)
@@ -2475,7 +2475,7 @@ packages:
       resolve: 2.0.0-next.5
       rfdc: 1.4.1
       safe-json-stringify: 1.2.0
-      semver: 7.6.3
+      semver: 7.7.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
       supports-color: 9.4.0
@@ -2515,7 +2515,7 @@ packages:
       '@iarna/toml': 2.2.5
       '@netlify/headers-parser': 7.3.0
       '@netlify/redirect-parser': 14.5.0
-      chalk: 5.3.0
+      chalk: 5.4.1
       cron-parser: 4.9.0
       deepmerge: 4.3.1
       dot-prop: 7.2.0
@@ -2561,7 +2561,7 @@ packages:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.1
@@ -2632,7 +2632,7 @@ packages:
       p-locate: 6.0.0
       process: 0.11.10
       read-package-up: 11.0.0
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /@netlify/functions-utils@5.3.7(supports-color@9.4.0):
@@ -2887,7 +2887,7 @@ packages:
       precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.6.3
+      semver: 7.7.1
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -2932,7 +2932,7 @@ packages:
       precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.6.3
+      semver: 7.7.1
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -3336,101 +3336,6 @@ packages:
     engines: {node: '>=18.0.0'}
     dev: false
 
-  /@remix-run/dev@2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3):
-    resolution: {integrity: sha512-agndQJHs7qISPXXH/Zet0VHWvcwtQGoEOXxltjerNQ2zWcAJQBm9i06tS6n6v/ZP0sHIVdo/IsvgAA4wetqmNw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@remix-run/react': ^2.15.3
-      '@remix-run/serve': ^2.15.3
-      typescript: ^5.1.0
-      vite: ^5.1.0
-      wrangler: ^3.28.2
-    peerDependenciesMeta:
-      '@remix-run/serve':
-        optional: true
-      typescript:
-        optional: true
-      vite:
-        optional: true
-      wrangler:
-        optional: true
-    dependencies:
-      '@babel/core': 7.26.9
-      '@babel/generator': 7.26.9
-      '@babel/parser': 7.26.9
-      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.9)
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
-      '@babel/traverse': 7.26.9
-      '@babel/types': 7.26.9
-      '@mdx-js/mdx': 2.3.0
-      '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.15.3(typescript@5.7.3)
-      '@remix-run/react': 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
-      '@remix-run/router': 1.22.0
-      '@remix-run/serve': 2.15.3(typescript@5.7.3)
-      '@remix-run/server-runtime': 2.15.3(typescript@5.7.3)
-      '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@20.17.30)
-      arg: 5.0.2
-      cacache: 17.1.4
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cross-spawn: 7.0.6
-      dotenv: 16.4.7
-      es-module-lexer: 1.6.0
-      esbuild: 0.17.6
-      esbuild-plugins-node-modules-polyfill: 1.7.0(esbuild@0.17.6)
-      execa: 5.1.1
-      exit-hook: 2.2.1
-      express: 4.21.2
-      fs-extra: 10.1.0
-      get-port: 5.1.1
-      gunzip-maybe: 1.4.2
-      jsesc: 3.0.2
-      json5: 2.2.3
-      lodash: 4.17.21
-      lodash.debounce: 4.0.8
-      minimatch: 9.0.5
-      ora: 5.4.1
-      picocolors: 1.1.1
-      picomatch: 2.3.1
-      pidtree: 0.6.0
-      postcss: 8.5.3
-      postcss-discard-duplicates: 5.1.0(postcss@8.5.3)
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2)
-      postcss-modules: 6.0.1(postcss@8.5.3)
-      prettier: 2.8.8
-      pretty-ms: 7.0.1
-      react-refresh: 0.14.2
-      remark-frontmatter: 4.0.1
-      remark-mdx-frontmatter: 1.1.1
-      semver: 7.7.1
-      set-cookie-parser: 2.7.1
-      tar-fs: 2.1.2
-      tsconfig-paths: 4.2.0
-      typescript: 5.7.3
-      valibot: 0.41.0(typescript@5.7.3)
-      vite-node: 1.6.1(@types/node@20.17.30)
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - bluebird
-      - bufferutil
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - ts-node
-      - utf-8-validate
-    dev: true
-
   /@remix-run/dev@2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5):
     resolution: {integrity: sha512-MzmcIjeEQkWAamSqWZm0tCdxxcK4HPFzaL8XCqkcRHVfhwJJXOZLp1GN/dHaokekI0cUvNIgCtm/bvHgjHb3Ng==}
     engines: {node: '>=18.0.0'}
@@ -3567,21 +3472,6 @@ packages:
       - supports-color
     dev: true
 
-  /@remix-run/express@2.15.3(express@4.21.2)(typescript@5.7.3):
-    resolution: {integrity: sha512-6a4S5KrRNiLDiaOneuoMpMMFo9ztB4gZ1AOJSX6BmqpXmcq/P+WhRXOqXrUYeL4fMstJhTVM8CzlInlfpem8Vw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      express: ^4.20.0
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/node': 2.15.3(typescript@5.7.3)
-      express: 4.21.2
-      typescript: 5.7.3
-    dev: true
-
   /@remix-run/express@2.16.4(express@4.21.2)(typescript@5.7.3):
     resolution: {integrity: sha512-VQ78Jq1BctEDXRkkPsR1ixMDuwUzW89MaPa+dFJ5f7V2et+0LMXEKmriLFWdCqToN88QM0GjMhSi5UkUUWLIjQ==}
     engines: {node: '>=18.0.0'}
@@ -3595,24 +3485,6 @@ packages:
       '@remix-run/node': 2.16.4(typescript@5.7.3)
       express: 4.21.2
       typescript: 5.7.3
-
-  /@remix-run/node@2.15.3(typescript@5.7.3):
-    resolution: {integrity: sha512-TYfS6BPhbABBpSRZ6WBA4qIWSwWvJhRVQGXCHUtgOwkuW863rcFmjh9g2Xj/IHyTmbOYPdcjHsIgZ9el4CHOKQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/server-runtime': 2.15.3(typescript@5.7.3)
-      '@remix-run/web-fetch': 4.4.2
-      '@web3-storage/multipart-parser': 1.0.0
-      cookie-signature: 1.2.2
-      source-map-support: 0.5.21
-      stream-slice: 0.1.2
-      typescript: 5.7.3
-      undici: 6.21.1
 
   /@remix-run/node@2.16.4(typescript@5.7.3):
     resolution: {integrity: sha512-scZwpc78cJS8dx6LMLemVHqnaAVbPWasx36TxYWUASA63hxPx5XbGbb6pe4cSpT8dWqhBtsPpHZoFTrM1aqx7A==}
@@ -3631,26 +3503,6 @@ packages:
       stream-slice: 0.1.2
       typescript: 5.7.3
       undici: 6.21.2
-
-  /@remix-run/react@2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-AynCltIk8KLlxV9a+4dORtEMNtF5wJAzBNBZLJMdw3FCJNQZRYQSen8rDnIovOOiz9UNZ2SmBTFERiFMKS16jw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/router': 1.22.0
-      '@remix-run/server-runtime': 2.15.3(typescript@5.7.3)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.29.0(react@18.3.1)
-      react-router-dom: 6.29.0(react-dom@18.3.1)(react@18.3.1)
-      turbo-stream: 2.4.0
-      typescript: 5.7.3
 
   /@remix-run/react@2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3):
     resolution: {integrity: sha512-sGQCrNGL8mlY7wKcW1zly+Hx9fSoDTYaAtt7INo54T1ubCIUKHlaVSfD2Ty67aZWYkyHBHgqAM8ZKtTJc1Uj8g==}
@@ -3672,31 +3524,9 @@ packages:
       turbo-stream: 2.4.0
       typescript: 5.7.3
 
-  /@remix-run/router@1.22.0:
-    resolution: {integrity: sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==}
-    engines: {node: '>=14.0.0'}
-
   /@remix-run/router@1.23.0:
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
-
-  /@remix-run/serve@2.15.3(typescript@5.7.3):
-    resolution: {integrity: sha512-7P0FWeNu1NEaSJpL2Xn8fZbr4zxkrOR6Qg03p7iYbipcQ1L0zr9Nxe5KKG4m9n8EyRWWxDV2L+wXHI7Ul9HiMw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      '@remix-run/express': 2.15.3(express@4.21.2)(typescript@5.7.3)
-      '@remix-run/node': 2.15.3(typescript@5.7.3)
-      chokidar: 3.6.0
-      compression: 1.8.0
-      express: 4.21.2
-      get-port: 5.1.1
-      morgan: 1.10.0
-      source-map-support: 0.5.21
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /@remix-run/serve@2.16.4(typescript@5.7.3):
     resolution: {integrity: sha512-9jYxxMI1RTKv7t1N53XzG3vQruWAaj6AYg4G5OoejtO7PZ6CbgbbHEiNa/f5ww3vhfcqZH7dfetDBdUYQ5PxVQ==}
@@ -3714,24 +3544,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  /@remix-run/server-runtime@2.15.3(typescript@5.7.3):
-    resolution: {integrity: sha512-taHBe1DEqxZNjjj6OfkSYbup+sZPjbTgUhykaI+nHqrC2NDQuTiisBXhLwtx60GctONR/x0lWhF7R9ZGC5WsHw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@remix-run/router': 1.22.0
-      '@types/cookie': 0.6.0
-      '@web3-storage/multipart-parser': 1.0.0
-      cookie: 0.6.0
-      set-cookie-parser: 2.7.1
-      source-map: 0.7.4
-      turbo-stream: 2.4.0
-      typescript: 5.7.3
 
   /@remix-run/server-runtime@2.16.4(typescript@5.7.3):
     resolution: {integrity: sha512-6M1Lq2mrH5zfGN++ay+a2KzdPqOh2TB7n6wYPPXA0rxQan8c5NZCvDFF635KS65LSzZDB+2VfFTgoPBERdYkYg==}
@@ -4095,11 +3907,6 @@ packages:
   /@types/node@20.5.1:
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
     dev: true
-
-  /@types/node@22.13.17:
-    resolution: {integrity: sha512-nAJuQXoyPj04uLgu+obZcSmsfOenUg6DxPKogeUy6yNCFwWaj5sBF8/G/pNo8EtBJjAfSVgfIlugR/BCOleO+g==}
-    dependencies:
-      undici-types: 6.20.0
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4713,7 +4520,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4796,7 +4603,7 @@ packages:
       global-cache-dir: 4.4.0
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.1
       write-file-atomic: 4.0.2
     dev: true
 
@@ -5309,7 +5116,7 @@ packages:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 7.0.1
-      chalk: 5.3.0
+      chalk: 5.4.1
       cli-boxes: 3.0.0
       string-width: 5.1.2
       type-fest: 2.19.0
@@ -5323,7 +5130,7 @@ packages:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 8.0.0
-      chalk: 5.3.0
+      chalk: 5.4.1
       cli-boxes: 3.0.0
       string-width: 7.2.0
       type-fest: 4.35.0
@@ -5812,7 +5619,7 @@ packages:
     resolution: {integrity: sha512-DP3FpjsiDDvnQC1OJBsdOJZPuy7r0o6sepY2T5M3L/d2nrE23O/ErFkEqyY3ngVL1ZhTj/H0pCMNObZGkEOaaQ==}
     engines: {node: '>=12.20.0'}
     dependencies:
-      chalk: 5.3.0
+      chalk: 5.4.1
       filter-obj: 3.0.0
       is-plain-obj: 4.1.0
       jest-validate: 27.5.1
@@ -5822,7 +5629,7 @@ packages:
     resolution: {integrity: sha512-Soe5lerRg3erMRgYC0EC696/8dMCGpBzcQchFfi55Yrkja8F+P7cUt0LVTIg7u5ob5BexLZ/F1kO+ejmv+nq8w==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      chalk: 5.3.0
+      chalk: 5.4.1
       is-plain-obj: 4.1.0
     dev: true
 
@@ -5937,7 +5744,7 @@ packages:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.6.3
+      semver: 7.7.1
       well-known-symbols: 2.0.0
     dev: true
 
@@ -6047,10 +5854,6 @@ packages:
   /cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
-
-  /cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
 
   /cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -6363,7 +6166,7 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug@4.3.7(supports-color@9.4.0):
+  /debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -6373,7 +6176,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-      supports-color: 9.4.0
     dev: true
 
   /debug@4.4.0(supports-color@9.4.0):
@@ -7267,6 +7069,36 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
+    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
+      debug: 3.2.7
+      eslint: 8.57.1
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
@@ -7395,7 +7227,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7936,7 +7768,7 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
-      '@types/node': 22.13.17
+      '@types/node': 20.17.30
       require-like: 0.1.2
 
   /event-target-shim@5.0.1:
@@ -8106,7 +7938,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -8219,7 +8051,7 @@ packages:
       proxy-addr: 2.0.7
       rfdc: 1.4.1
       secure-json-parse: 2.7.0
-      semver: 7.6.3
+      semver: 7.7.1
       toad-cache: 3.7.0
     dev: true
 
@@ -8473,7 +8305,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
     dev: true
 
   /for-each@0.3.5:
@@ -8734,7 +8566,7 @@ packages:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
       node-fetch: 3.3.2
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /git-raw-commits@2.0.11:
@@ -9169,7 +9001,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2(supports-color@9.4.0)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9179,7 +9011,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10049,7 +9881,7 @@ packages:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /jsx-ast-utils@3.3.5:
@@ -10399,7 +10231,7 @@ packages:
       jest-validate: 27.5.1
       map-obj: 5.0.2
       moize: 6.1.6
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /log-symbols@3.0.0:
@@ -10420,7 +10252,7 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
     dependencies:
-      chalk: 5.3.0
+      chalk: 5.4.1
       is-unicode-supported: 1.3.0
     dev: true
 
@@ -10516,7 +10348,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /make-error@1.3.6:
@@ -11342,7 +11174,7 @@ packages:
       content-type: 1.0.5
       cookie: 0.7.2
       cron-parser: 4.9.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7
       decache: 4.6.2
       dot-prop: 9.0.0
       dotenv: 16.4.7
@@ -11480,7 +11312,7 @@ packages:
     resolution: {integrity: sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /node-addon-api@6.1.0:
@@ -11559,7 +11391,7 @@ packages:
       is-plain-obj: 4.1.0
       normalize-node-version: 12.4.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /nopt@5.0.0:
@@ -11576,7 +11408,7 @@ packages:
     dependencies:
       all-node-versions: 11.3.0
       filter-obj: 5.1.0
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /normalize-package-data@2.5.0:
@@ -11594,7 +11426,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -11612,7 +11444,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.6.3
+      semver: 7.7.1
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -11928,7 +11760,7 @@ packages:
     resolution: {integrity: sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==}
     engines: {node: '>=18'}
     dependencies:
-      chalk: 5.3.0
+      chalk: 5.4.1
       cli-cursor: 5.0.0
       cli-spinners: 2.9.2
       is-interactive: 2.0.0
@@ -12143,7 +11975,7 @@ packages:
       ky: 1.7.5
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
-      semver: 7.6.3
+      semver: 7.7.1
     dev: true
 
   /pako@0.2.9:
@@ -12867,18 +12699,6 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  /react-router-dom@6.29.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.22.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.29.0(react@18.3.1)
-
   /react-router-dom@6.30.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==}
     engines: {node: '>=14.0.0'}
@@ -12890,15 +12710,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.0(react@18.3.1)
-
-  /react-router@6.29.0(react@18.3.1):
-    resolution: {integrity: sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.22.0
-      react: 18.3.1
 
   /react-router@6.30.0(react@18.3.1):
     resolution: {integrity: sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==}
@@ -13556,7 +13367,7 @@ packages:
       detect-libc: 2.0.3
       node-addon-api: 6.1.0
       prebuild-install: 7.1.3
-      semver: 7.6.3
+      semver: 7.7.1
       simple-get: 4.0.1
       tar-fs: 3.0.8
       tunnel-agent: 0.6.0
@@ -14155,7 +13966,7 @@ packages:
   /tabtab@3.0.2:
     resolution: {integrity: sha512-jANKmUe0sIQc/zTALTBy186PoM/k6aPrh3A7p6AaAfF6WPSbTx1JYeGIGH162btpH+mmVEXln+UxwViZHO2Jhg==}
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
       es6-promisify: 6.1.1
       inquirer: 6.5.2
       minimist: 1.2.8
@@ -14734,13 +14545,6 @@ packages:
   /undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  /undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
-
-  /undici@6.21.1:
-    resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
-    engines: {node: '>=18.17'}
-
   /undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
     engines: {node: '>=18.17'}
@@ -14961,14 +14765,14 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       boxen: 8.0.1
-      chalk: 5.3.0
+      chalk: 5.4.1
       configstore: 7.0.0
       is-in-ci: 1.0.0
       is-installed-globally: 1.0.0
       is-npm: 6.0.0
       latest-version: 9.0.0
       pupa: 3.1.0
-      semver: 7.6.3
+      semver: 7.7.1
       xdg-basedir: 5.1.0
     dev: true
 
@@ -15308,7 +15112,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.4.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)
       '@remix-run/eslint-config':
         specifier: ^2.9.2
         version: 2.15.3(eslint@8.57.1)(react@18.3.1)(typescript@5.7.3)
@@ -151,7 +151,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)
       '@remix-run/eslint-config':
         specifier: ^2.9.2
         version: 2.15.3(eslint@8.57.1)(react@18.3.1)(typescript@5.7.3)
@@ -174,17 +174,20 @@ importers:
   demos/vite-edge:
     dependencies:
       '@netlify/remix-edge-adapter':
-        specifier: ^3.4.2
+        specifier: workspace:*
         version: link:../../packages/remix-edge-adapter
       '@netlify/remix-runtime':
-        specifier: ^2.3.1
+        specifier: workspace:*
         version: link:../../packages/remix-runtime
+      '@remix-run/node':
+        specifier: ^2.16.4
+        version: 2.16.4(typescript@5.7.3)
       '@remix-run/react':
-        specifier: ^2.9.2
-        version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
       '@remix-run/serve':
-        specifier: ^2.9.2
-        version: 2.15.3(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(typescript@5.7.3)
       isbot:
         specifier: ^5.0.0
         version: 5.1.25
@@ -199,8 +202,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@remix-run/dev':
-        specifier: ^2.9.2
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        specifier: ^2.16.4
+        version: 2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5)
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.20
@@ -235,26 +238,26 @@ importers:
         specifier: ^5.1.6
         version: 5.7.3
       vite:
-        specifier: ^5.0.0
-        version: 5.4.14(@types/node@20.17.30)
+        specifier: ^6.2.5
+        version: 6.2.5(@types/node@20.17.30)
       vite-tsconfig-paths:
-        specifier: ^4.2.1
-        version: 4.3.2(typescript@5.7.3)(vite@5.4.14)
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.5)
 
   demos/vite-functions:
     dependencies:
       '@netlify/remix-adapter':
-        specifier: ^2.6.0
+        specifier: workspace:*
         version: link:../../packages/remix-adapter
       '@remix-run/node':
-        specifier: ^2.9.2
-        version: 2.15.3(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(typescript@5.7.3)
       '@remix-run/react':
-        specifier: ^2.9.2
-        version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
       '@remix-run/serve':
-        specifier: ^2.9.2
-        version: 2.15.3(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(typescript@5.7.3)
       isbot:
         specifier: ^5.0.0
         version: 5.1.25
@@ -266,8 +269,8 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@remix-run/dev':
-        specifier: ^2.9.2
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        specifier: ^2.16.4
+        version: 2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5)
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.20
@@ -302,11 +305,11 @@ importers:
         specifier: ^5.1.6
         version: 5.7.3
       vite:
-        specifier: ^5.0.0
-        version: 5.4.14(@types/node@20.17.30)
+        specifier: ^6.2.5
+        version: 6.2.5(@types/node@20.17.30)
       vite-tsconfig-paths:
-        specifier: ^4.2.1
-        version: 4.3.2(typescript@5.7.3)(vite@5.4.14)
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.7.3)(vite@6.2.5)
 
   packages/remix-adapter:
     dependencies:
@@ -322,7 +325,7 @@ importers:
         version: 3.0.0
       '@remix-run/dev':
         specifier: ^2.12.0
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        version: 2.15.3(@remix-run/react@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
       '@remix-run/react':
         specifier: ^2.12.0
         version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
@@ -352,7 +355,7 @@ importers:
         version: link:../remix-runtime
       '@remix-run/dev':
         specifier: ^2.12.0
-        version: 2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        version: 2.15.3(@remix-run/react@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
       isbot:
         specifier: ^5.0.0
         version: 5.1.25
@@ -1205,7 +1208,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/aix-ppc64@0.21.2:
@@ -1248,7 +1250,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.21.2:
@@ -1291,7 +1292,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.21.2:
@@ -1334,7 +1334,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.21.2:
@@ -1377,7 +1376,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.21.2:
@@ -1420,7 +1418,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.21.2:
@@ -1463,7 +1460,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.21.2:
@@ -1506,7 +1502,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.21.2:
@@ -1549,7 +1544,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.21.2:
@@ -1592,7 +1586,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.21.2:
@@ -1635,7 +1628,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.21.2:
@@ -1678,7 +1670,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.21.2:
@@ -1721,7 +1712,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.21.2:
@@ -1764,7 +1754,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.21.2:
@@ -1807,7 +1796,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.21.2:
@@ -1850,7 +1838,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.21.2:
@@ -1893,7 +1880,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.21.2:
@@ -1945,7 +1931,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.21.2:
@@ -1997,7 +1982,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.21.2:
@@ -2040,7 +2024,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.21.2:
@@ -2083,7 +2066,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.21.2:
@@ -2126,7 +2108,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.21.2:
@@ -2169,7 +2150,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.21.2:
@@ -3378,7 +3358,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dev: false
 
-  /@remix-run/dev@2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14):
+  /@remix-run/dev@2.15.3(@remix-run/react@2.15.3)(@remix-run/serve@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3):
     resolution: {integrity: sha512-agndQJHs7qISPXXH/Zet0VHWvcwtQGoEOXxltjerNQ2zWcAJQBm9i06tS6n6v/ZP0sHIVdo/IsvgAA4wetqmNw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -3454,6 +3434,100 @@ packages:
       tsconfig-paths: 4.2.0
       typescript: 5.7.3
       valibot: 0.41.0(typescript@5.7.3)
+      vite-node: 1.6.1(@types/node@20.17.30)
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - bluebird
+      - bufferutil
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /@remix-run/dev@2.15.3(@remix-run/react@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14):
+    resolution: {integrity: sha512-agndQJHs7qISPXXH/Zet0VHWvcwtQGoEOXxltjerNQ2zWcAJQBm9i06tS6n6v/ZP0sHIVdo/IsvgAA4wetqmNw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@remix-run/react': ^2.15.3
+      '@remix-run/serve': ^2.15.3
+      typescript: ^5.1.0
+      vite: ^5.1.0
+      wrangler: ^3.28.2
+    peerDependenciesMeta:
+      '@remix-run/serve':
+        optional: true
+      typescript:
+        optional: true
+      vite:
+        optional: true
+      wrangler:
+        optional: true
+    dependencies:
+      '@babel/core': 7.26.9
+      '@babel/generator': 7.26.9
+      '@babel/parser': 7.26.9
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.9)
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
+      '@mdx-js/mdx': 2.3.0
+      '@npmcli/package-json': 4.0.1
+      '@remix-run/node': 2.15.3(typescript@5.7.3)
+      '@remix-run/react': 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+      '@remix-run/router': 1.22.0
+      '@remix-run/server-runtime': 2.15.3(typescript@5.7.3)
+      '@types/mdx': 2.0.13
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.17.30)
+      arg: 5.0.2
+      cacache: 17.1.4
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      cross-spawn: 7.0.6
+      dotenv: 16.4.7
+      es-module-lexer: 1.6.0
+      esbuild: 0.17.6
+      esbuild-plugins-node-modules-polyfill: 1.7.0(esbuild@0.17.6)
+      execa: 5.1.1
+      exit-hook: 2.2.1
+      express: 4.21.2
+      fs-extra: 10.1.0
+      get-port: 5.1.1
+      gunzip-maybe: 1.4.2
+      jsesc: 3.0.2
+      json5: 2.2.3
+      lodash: 4.17.21
+      lodash.debounce: 4.0.8
+      minimatch: 9.0.5
+      ora: 5.4.1
+      picocolors: 1.1.1
+      picomatch: 2.3.1
+      pidtree: 0.6.0
+      postcss: 8.5.3
+      postcss-discard-duplicates: 5.1.0(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2)
+      postcss-modules: 6.0.1(postcss@8.5.3)
+      prettier: 2.8.8
+      pretty-ms: 7.0.1
+      react-refresh: 0.14.2
+      remark-frontmatter: 4.0.1
+      remark-mdx-frontmatter: 1.1.1
+      semver: 7.7.1
+      set-cookie-parser: 2.7.1
+      tar-fs: 2.1.2
+      tsconfig-paths: 4.2.0
+      typescript: 5.7.3
+      valibot: 0.41.0(typescript@5.7.3)
       vite: 5.4.14(@types/node@20.17.30)
       vite-node: 1.6.1(@types/node@20.17.30)
       ws: 7.5.10
@@ -3472,6 +3546,103 @@ packages:
       - terser
       - ts-node
       - utf-8-validate
+
+  /@remix-run/dev@2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5):
+    resolution: {integrity: sha512-MzmcIjeEQkWAamSqWZm0tCdxxcK4HPFzaL8XCqkcRHVfhwJJXOZLp1GN/dHaokekI0cUvNIgCtm/bvHgjHb3Ng==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@remix-run/react': ^2.16.4
+      '@remix-run/serve': ^2.16.4
+      typescript: ^5.1.0
+      vite: ^5.1.0 || ^6.0.0
+      wrangler: ^3.28.2
+    peerDependenciesMeta:
+      '@remix-run/serve':
+        optional: true
+      typescript:
+        optional: true
+      vite:
+        optional: true
+      wrangler:
+        optional: true
+    dependencies:
+      '@babel/core': 7.26.9
+      '@babel/generator': 7.26.9
+      '@babel/parser': 7.26.9
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.9)
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
+      '@babel/traverse': 7.26.9
+      '@babel/types': 7.26.9
+      '@mdx-js/mdx': 2.3.0
+      '@npmcli/package-json': 4.0.1
+      '@remix-run/node': 2.16.4(typescript@5.7.3)
+      '@remix-run/react': 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+      '@remix-run/router': 1.23.0
+      '@remix-run/serve': 2.16.4(typescript@5.7.3)
+      '@remix-run/server-runtime': 2.16.4(typescript@5.7.3)
+      '@types/mdx': 2.0.13
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.17.30)
+      arg: 5.0.2
+      cacache: 17.1.4
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      cross-spawn: 7.0.6
+      dotenv: 16.4.7
+      es-module-lexer: 1.6.0
+      esbuild: 0.17.6
+      esbuild-plugins-node-modules-polyfill: 1.7.0(esbuild@0.17.6)
+      execa: 5.1.1
+      exit-hook: 2.2.1
+      express: 4.21.2
+      fs-extra: 10.1.0
+      get-port: 5.1.1
+      gunzip-maybe: 1.4.2
+      jsesc: 3.0.2
+      json5: 2.2.3
+      lodash: 4.17.21
+      lodash.debounce: 4.0.8
+      minimatch: 9.0.5
+      ora: 5.4.1
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      picomatch: 2.3.1
+      pidtree: 0.6.0
+      postcss: 8.5.3
+      postcss-discard-duplicates: 5.1.0(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2)
+      postcss-modules: 6.0.1(postcss@8.5.3)
+      prettier: 2.8.8
+      pretty-ms: 7.0.1
+      react-refresh: 0.14.2
+      remark-frontmatter: 4.0.1
+      remark-mdx-frontmatter: 1.1.1
+      semver: 7.7.1
+      set-cookie-parser: 2.7.1
+      tar-fs: 2.1.2
+      tsconfig-paths: 4.2.0
+      typescript: 5.7.3
+      valibot: 0.41.0(typescript@5.7.3)
+      vite: 6.2.5(@types/node@20.17.30)
+      vite-node: 3.0.0-beta.2(@types/node@20.17.30)
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - bluebird
+      - bufferutil
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - ts-node
+      - utf-8-validate
+    dev: true
 
   /@remix-run/eslint-config@2.15.3(eslint@8.57.1)(react@18.3.1)(typescript@5.7.3):
     resolution: {integrity: sha512-p9V3rvFAgFRPyjxZnW9bTR7WZfTl13wcbfWtySWcNdeqJZauCN9xdkB1r+PnsjaK77RXWtSCsEgRn/+mwx9Kzg==}
@@ -3523,6 +3694,21 @@ packages:
       '@remix-run/node': 2.15.3(typescript@5.7.3)
       express: 4.21.2
       typescript: 5.7.3
+    dev: true
+
+  /@remix-run/express@2.16.4(express@4.21.2)(typescript@5.7.3):
+    resolution: {integrity: sha512-VQ78Jq1BctEDXRkkPsR1ixMDuwUzW89MaPa+dFJ5f7V2et+0LMXEKmriLFWdCqToN88QM0GjMhSi5UkUUWLIjQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      express: ^4.20.0
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/node': 2.16.4(typescript@5.7.3)
+      express: 4.21.2
+      typescript: 5.7.3
 
   /@remix-run/node@2.15.3(typescript@5.7.3):
     resolution: {integrity: sha512-TYfS6BPhbABBpSRZ6WBA4qIWSwWvJhRVQGXCHUtgOwkuW863rcFmjh9g2Xj/IHyTmbOYPdcjHsIgZ9el4CHOKQ==}
@@ -3541,6 +3727,24 @@ packages:
       stream-slice: 0.1.2
       typescript: 5.7.3
       undici: 6.21.1
+
+  /@remix-run/node@2.16.4(typescript@5.7.3):
+    resolution: {integrity: sha512-scZwpc78cJS8dx6LMLemVHqnaAVbPWasx36TxYWUASA63hxPx5XbGbb6pe4cSpT8dWqhBtsPpHZoFTrM1aqx7A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/server-runtime': 2.16.4(typescript@5.7.3)
+      '@remix-run/web-fetch': 4.4.2
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie-signature: 1.2.2
+      source-map-support: 0.5.21
+      stream-slice: 0.1.2
+      typescript: 5.7.3
+      undici: 6.21.2
 
   /@remix-run/react@2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3):
     resolution: {integrity: sha512-AynCltIk8KLlxV9a+4dORtEMNtF5wJAzBNBZLJMdw3FCJNQZRYQSen8rDnIovOOiz9UNZ2SmBTFERiFMKS16jw==}
@@ -3562,8 +3766,32 @@ packages:
       turbo-stream: 2.4.0
       typescript: 5.7.3
 
+  /@remix-run/react@2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3):
+    resolution: {integrity: sha512-sGQCrNGL8mlY7wKcW1zly+Hx9fSoDTYaAtt7INo54T1ubCIUKHlaVSfD2Ty67aZWYkyHBHgqAM8ZKtTJc1Uj8g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/router': 1.23.0
+      '@remix-run/server-runtime': 2.16.4(typescript@5.7.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.0(react@18.3.1)
+      react-router-dom: 6.30.0(react-dom@18.3.1)(react@18.3.1)
+      turbo-stream: 2.4.0
+      typescript: 5.7.3
+
   /@remix-run/router@1.22.0:
     resolution: {integrity: sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==}
+    engines: {node: '>=14.0.0'}
+
+  /@remix-run/router@1.23.0:
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
 
   /@remix-run/serve@2.15.3(typescript@5.7.3):
@@ -3573,6 +3801,24 @@ packages:
     dependencies:
       '@remix-run/express': 2.15.3(express@4.21.2)(typescript@5.7.3)
       '@remix-run/node': 2.15.3(typescript@5.7.3)
+      chokidar: 3.6.0
+      compression: 1.8.0
+      express: 4.21.2
+      get-port: 5.1.1
+      morgan: 1.10.0
+      source-map-support: 0.5.21
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@remix-run/serve@2.16.4(typescript@5.7.3):
+    resolution: {integrity: sha512-9jYxxMI1RTKv7t1N53XzG3vQruWAaj6AYg4G5OoejtO7PZ6CbgbbHEiNa/f5ww3vhfcqZH7dfetDBdUYQ5PxVQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      '@remix-run/express': 2.16.4(express@4.21.2)(typescript@5.7.3)
+      '@remix-run/node': 2.16.4(typescript@5.7.3)
       chokidar: 3.6.0
       compression: 1.8.0
       express: 4.21.2
@@ -3596,6 +3842,24 @@ packages:
       '@types/cookie': 0.6.0
       '@web3-storage/multipart-parser': 1.0.0
       cookie: 0.6.0
+      set-cookie-parser: 2.7.1
+      source-map: 0.7.4
+      turbo-stream: 2.4.0
+      typescript: 5.7.3
+
+  /@remix-run/server-runtime@2.16.4(typescript@5.7.3):
+    resolution: {integrity: sha512-6M1Lq2mrH5zfGN++ay+a2KzdPqOh2TB7n6wYPPXA0rxQan8c5NZCvDFF635KS65LSzZDB+2VfFTgoPBERdYkYg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@remix-run/router': 1.23.0
+      '@types/cookie': 0.6.0
+      '@web3-storage/multipart-parser': 1.0.0
+      cookie: 0.7.2
       set-cookie-parser: 2.7.1
       source-map: 0.7.4
       turbo-stream: 2.4.0
@@ -4300,7 +4564,7 @@ packages:
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.9)
       '@vanilla-extract/babel-plugin-debug-ids': 1.2.0
       '@vanilla-extract/css': 1.17.1
-      esbuild: 0.17.6
+      esbuild: 0.19.11
       eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0
@@ -5909,7 +6173,6 @@ packages:
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
@@ -6890,7 +7153,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.11
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
-    dev: true
 
   /esbuild@0.21.2:
     resolution: {integrity: sha512-LmHPAa5h4tSxz+g/D8IHY6wCjtIiFx8I7/Q0Aq+NmvtoYvyMnJU0KQJcqB6QH30X9x/W4CemgUtPgQDZFca5SA==}
@@ -7120,36 +7382,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
-    resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 3.2.7
-      eslint: 8.57.1
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
     engines: {node: '>=4'}
@@ -7278,7 +7510,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12762,6 +12994,18 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.29.0(react@18.3.1)
 
+  /react-router-dom@6.30.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.0(react@18.3.1)
+
   /react-router@6.29.0(react@18.3.1):
     resolution: {integrity: sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==}
     engines: {node: '>=14.0.0'}
@@ -12769,6 +13013,15 @@ packages:
       react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.22.0
+      react: 18.3.1
+
+  /react-router@6.30.0(react@18.3.1):
+    resolution: {integrity: sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.23.0
       react: 18.3.1
 
   /react-router@7.4.1(react-dom@18.3.1)(react@18.3.1):
@@ -14606,7 +14859,6 @@ packages:
   /undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
     engines: {node: '>=18.17'}
-    dev: false
 
   /unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -14980,8 +15232,30 @@ packages:
       - terser
     dev: true
 
-  /vite-tsconfig-paths@4.3.2(typescript@5.7.3)(vite@5.4.14):
-    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
+  /vite-node@3.0.0-beta.2(@types/node@20.17.30):
+    resolution: {integrity: sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0(supports-color@9.4.0)
+      es-module-lexer: 1.6.0
+      pathe: 1.1.2
+      vite: 5.4.14(@types/node@20.17.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.2.5):
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
@@ -14991,7 +15265,7 @@ packages:
       debug: 4.4.0(supports-color@9.4.0)
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.7.3)
-      vite: 5.4.14(@types/node@20.17.30)
+      vite: 6.2.5(@types/node@20.17.30)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15034,6 +15308,54 @@ packages:
       rollup: 4.34.8
     optionalDependencies:
       fsevents: 2.3.3
+
+  /vite@6.2.5(@types/node@20.17.30):
+    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 20.17.30
+      esbuild: 0.25.0
+      postcss: 8.5.3
+      rollup: 4.34.8
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /vitest@2.1.9(@types/node@20.17.30):
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ importers:
   packages/remix-adapter:
     dependencies:
       '@remix-run/node':
-        specifier: ^2.12.0
-        version: 2.15.3(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(typescript@5.7.3)
       isbot:
         specifier: ^5.0.0
         version: 5.1.25
@@ -324,11 +324,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@remix-run/dev':
-        specifier: ^2.12.0
-        version: 2.15.3(@remix-run/react@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        specifier: ^2.16.4
+        version: 2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5)
       '@remix-run/react':
-        specifier: ^2.12.0
-        version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
       '@types/react':
         specifier: ^18.0.27
         version: 18.3.20
@@ -345,8 +345,8 @@ importers:
         specifier: ^8.0.2
         version: 8.4.0(postcss@8.5.3)(typescript@5.7.3)
       vite:
-        specifier: ^5.4.11
-        version: 5.4.14(@types/node@20.17.30)
+        specifier: ^6.2.5
+        version: 6.2.5(@types/node@20.17.30)
 
   packages/remix-edge-adapter:
     dependencies:
@@ -354,15 +354,18 @@ importers:
         specifier: 2.3.1
         version: link:../remix-runtime
       '@remix-run/dev':
-        specifier: ^2.12.0
-        version: 2.15.3(@remix-run/react@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14)
+        specifier: ^2.16.4
+        version: 2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5)
+      '@remix-run/node':
+        specifier: ^2.16.4
+        version: 2.16.4(typescript@5.7.3)
       isbot:
         specifier: ^5.0.0
         version: 5.1.25
     devDependencies:
       '@remix-run/react':
-        specifier: ^2.12.0
-        version: 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
+        specifier: ^2.16.4
+        version: 2.16.4(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
       '@types/react':
         specifier: ^18.0.27
         version: 18.3.20
@@ -379,8 +382,8 @@ importers:
         specifier: ^8.0.2
         version: 8.4.0(postcss@8.5.3)(typescript@5.7.3)
       vite:
-        specifier: ^5.1.3
-        version: 5.4.14(@types/node@20.17.30)
+        specifier: ^6.2.5
+        version: 6.2.5(@types/node@20.17.30)
 
   packages/remix-runtime:
     devDependencies:
@@ -422,8 +425,8 @@ importers:
         specifier: ^8.0.2
         version: 8.4.0(postcss@8.5.3)(typescript@5.7.3)
       vite:
-        specifier: ^5.4.11
-        version: 5.4.14(@types/node@20.17.30)
+        specifier: ^6.2.5
+        version: 6.2.5(@types/node@20.17.30)
 
 packages:
 
@@ -1233,7 +1236,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.17.6:
@@ -1275,7 +1277,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.17.6:
@@ -1317,7 +1318,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.17.6:
@@ -1359,7 +1359,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.17.6:
@@ -1401,7 +1400,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.17.6:
@@ -1443,7 +1441,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.17.6:
@@ -1485,7 +1482,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.17.6:
@@ -1527,7 +1523,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.17.6:
@@ -1569,7 +1564,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.17.6:
@@ -1611,7 +1605,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.17.6:
@@ -1653,7 +1646,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.17.6:
@@ -1695,7 +1687,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.17.6:
@@ -1737,7 +1728,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.17.6:
@@ -1779,7 +1769,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.17.6:
@@ -1821,7 +1810,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.17.6:
@@ -1863,7 +1851,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.17.6:
@@ -1905,7 +1892,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-arm64@0.25.0:
@@ -1914,7 +1900,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.17.6:
@@ -1956,7 +1941,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-arm64@0.25.0:
@@ -1965,7 +1949,6 @@ packages:
     cpu: [arm64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.17.6:
@@ -2007,7 +1990,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.17.6:
@@ -2049,7 +2031,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.17.6:
@@ -2091,7 +2072,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.17.6:
@@ -2133,7 +2113,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.17.6:
@@ -2175,7 +2154,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.1(eslint@8.57.1):
@@ -3453,100 +3431,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@remix-run/dev@2.15.3(@remix-run/react@2.15.3)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@5.4.14):
-    resolution: {integrity: sha512-agndQJHs7qISPXXH/Zet0VHWvcwtQGoEOXxltjerNQ2zWcAJQBm9i06tS6n6v/ZP0sHIVdo/IsvgAA4wetqmNw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@remix-run/react': ^2.15.3
-      '@remix-run/serve': ^2.15.3
-      typescript: ^5.1.0
-      vite: ^5.1.0
-      wrangler: ^3.28.2
-    peerDependenciesMeta:
-      '@remix-run/serve':
-        optional: true
-      typescript:
-        optional: true
-      vite:
-        optional: true
-      wrangler:
-        optional: true
-    dependencies:
-      '@babel/core': 7.26.9
-      '@babel/generator': 7.26.9
-      '@babel/parser': 7.26.9
-      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.9)
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
-      '@babel/traverse': 7.26.9
-      '@babel/types': 7.26.9
-      '@mdx-js/mdx': 2.3.0
-      '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.15.3(typescript@5.7.3)
-      '@remix-run/react': 2.15.3(react-dom@18.3.1)(react@18.3.1)(typescript@5.7.3)
-      '@remix-run/router': 1.22.0
-      '@remix-run/server-runtime': 2.15.3(typescript@5.7.3)
-      '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@20.17.30)
-      arg: 5.0.2
-      cacache: 17.1.4
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cross-spawn: 7.0.6
-      dotenv: 16.4.7
-      es-module-lexer: 1.6.0
-      esbuild: 0.17.6
-      esbuild-plugins-node-modules-polyfill: 1.7.0(esbuild@0.17.6)
-      execa: 5.1.1
-      exit-hook: 2.2.1
-      express: 4.21.2
-      fs-extra: 10.1.0
-      get-port: 5.1.1
-      gunzip-maybe: 1.4.2
-      jsesc: 3.0.2
-      json5: 2.2.3
-      lodash: 4.17.21
-      lodash.debounce: 4.0.8
-      minimatch: 9.0.5
-      ora: 5.4.1
-      picocolors: 1.1.1
-      picomatch: 2.3.1
-      pidtree: 0.6.0
-      postcss: 8.5.3
-      postcss-discard-duplicates: 5.1.0(postcss@8.5.3)
-      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2)
-      postcss-modules: 6.0.1(postcss@8.5.3)
-      prettier: 2.8.8
-      pretty-ms: 7.0.1
-      react-refresh: 0.14.2
-      remark-frontmatter: 4.0.1
-      remark-mdx-frontmatter: 1.1.1
-      semver: 7.7.1
-      set-cookie-parser: 2.7.1
-      tar-fs: 2.1.2
-      tsconfig-paths: 4.2.0
-      typescript: 5.7.3
-      valibot: 0.41.0(typescript@5.7.3)
-      vite: 5.4.14(@types/node@20.17.30)
-      vite-node: 1.6.1(@types/node@20.17.30)
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - bluebird
-      - bufferutil
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - ts-node
-      - utf-8-validate
-
   /@remix-run/dev@2.16.4(@remix-run/react@2.16.4)(@remix-run/serve@2.16.4)(@types/node@20.17.30)(ts-node@10.9.2)(typescript@5.7.3)(vite@6.2.5):
     resolution: {integrity: sha512-MzmcIjeEQkWAamSqWZm0tCdxxcK4HPFzaL8XCqkcRHVfhwJJXOZLp1GN/dHaokekI0cUvNIgCtm/bvHgjHb3Ng==}
     engines: {node: '>=18.0.0'}
@@ -3632,6 +3516,7 @@ packages:
       - babel-plugin-macros
       - bluebird
       - bufferutil
+      - jiti
       - less
       - lightningcss
       - sass
@@ -3641,8 +3526,9 @@ packages:
       - supports-color
       - terser
       - ts-node
+      - tsx
       - utf-8-validate
-    dev: true
+      - yaml
 
   /@remix-run/eslint-config@2.15.3(eslint@8.57.1)(react@18.3.1)(typescript@5.7.3):
     resolution: {integrity: sha512-p9V3rvFAgFRPyjxZnW9bTR7WZfTl13wcbfWtySWcNdeqJZauCN9xdkB1r+PnsjaK77RXWtSCsEgRn/+mwx9Kzg==}
@@ -7246,7 +7132,6 @@ packages:
       '@esbuild/win32-arm64': 0.25.0
       '@esbuild/win32-ia32': 0.25.0
       '@esbuild/win32-x64': 0.25.0
-    dev: true
 
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -15241,9 +15126,10 @@ packages:
       debug: 4.4.0(supports-color@9.4.0)
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.14(@types/node@20.17.30)
+      vite: 6.2.5(@types/node@20.17.30)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -15252,7 +15138,8 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
+      - tsx
+      - yaml
 
   /vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.2.5):
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
@@ -15355,7 +15242,6 @@ packages:
       rollup: 4.34.8
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitest@2.1.9(@types/node@20.17.30):
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}

--- a/tests/e2e/fixtures/edge-site/package.json
+++ b/tests/e2e/fixtures/edge-site/package.json
@@ -13,15 +13,16 @@
   "dependencies": {
     "@netlify/remix-edge-adapter": "*",
     "@netlify/remix-runtime": "*",
-    "@remix-run/react": "^2.12.1-pre",
-    "@remix-run/serve": "^2.12.1-pre",
+    "@remix-run/node": "^2.16.4",
+    "@remix-run/react": "^2.16.4",
+    "@remix-run/serve": "^2.16.4",
     "isbot": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@netlify/functions": "^3.0.0",
-    "@remix-run/dev": "^2.12.1-pre",
+    "@remix-run/dev": "^2.16.4",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -33,8 +34,8 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.6",
-    "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite": "^6.2.5",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/tests/e2e/fixtures/react-router-serverless-site/package.json
+++ b/tests/e2e/fixtures/react-router-serverless-site/package.json
@@ -10,17 +10,17 @@
   },
   "dependencies": {
     "@netlify/blobs": "^8.1.2",
-    "@react-router/node": "^7.1.0-pre",
-    "@react-router/serve": "^7.1.0-pre",
+    "@react-router/node": "^7.4.1",
+    "@react-router/serve": "^7.4.1",
     "isbot": "^5.1.17",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.1.0-pre"
+    "react-router": "^7.4.1"
   },
   "devDependencies": {
     "@netlify/functions": "^3.0.0",
     "@netlify/vite-plugin-react-router": "*",
-    "@react-router/dev": "^7.1.0-pre",
+    "@react-router/dev": "^7.4.1",
     "@types/node": "^20",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -28,7 +28,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.6.3",
-    "vite": "^5.4.11",
-    "vite-tsconfig-paths": "^5.1.2"
+    "vite": "^6.2.5",
+    "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/tests/e2e/fixtures/serverless-site/package.json
+++ b/tests/e2e/fixtures/serverless-site/package.json
@@ -13,16 +13,16 @@
   "dependencies": {
     "@netlify/blobs": "^8.1.2",
     "@netlify/remix-adapter": "*",
-    "@remix-run/node": "^2.12.1-pre",
-    "@remix-run/react": "^2.12.1-pre",
-    "@remix-run/serve": "^2.12.1-pre",
+    "@remix-run/node": "^2.16.4",
+    "@remix-run/react": "^2.16.4",
+    "@remix-run/serve": "^2.16.4",
     "isbot": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@netlify/functions": "^3.0.0",
-    "@remix-run/dev": "^2.12.1-pre",
+    "@remix-run/dev": "^2.16.4",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -34,8 +34,8 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^5.1.6",
-    "vite": "^5.0.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite": "^6.2.5",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Description

- Update peer dependencies of all packages to allow Vite 6
- Update demos and test fixtures to test against Vite 6

## Related Tickets & Documents

Fixes #496