### PR TITLE
chore: re-enable playwright parallelization

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig } from '@playwright/test'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -7,7 +7,6 @@ export default defineConfig({
   testDir: './tests/e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
-  workers: 1,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */


### PR DESCRIPTION
## Description

We had turned this off long ago in a blind attempt to fix flakiness.

We [recently *actually* fixed flakiness](https://github.com/netlify/remix-compute/pull/547), which turned out to be unrelated to this.

This significantly speeds up our CI, from ~12m to ~6m.