### PR TITLE
fix(docs): fix wrong class name in readme

### DIFF
--- a/packages/vite-plugin-react-router/README.md
+++ b/packages/vite-plugin-react-router/README.md
@@ -101,7 +101,7 @@ To use middleware,
 that this requires requires v2.0.0+ of `@netlify/vite-plugin-react-router`.
 
 To access the [Netlify context](https://docs.netlify.com/build/functions/api/#netlify-specific-context-object)
-specifically, you must import our `RouterContextProvider` instance:
+specifically, you must import our `RouterContext` instance:
 
 ```tsx
 import { netlifyRouterContext } from '@netlify/vite-plugin-react-router'


### PR DESCRIPTION
You call `ctxProvider.get(ctx)` _on_ a `RouterContextProvider` and pass in a `RouterContext`. My bad.