### PR TITLE
chore(renovate): unset `minimumReleaseAge` for frameworks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,7 @@
       matchSourceUrls: ['https://github.com/remix-run/remix'],
       // Override the schedule to get immediate PRs.
       schedule: null,
+      minimumReleaseAge: null,
       // Apply a unique label so we can trigger additional workflows for these PRs.
       addLabels: ['bump-framework-in-fixtures'],
       // Bump even if the release isn't tagged as `latest`.
@@ -36,6 +37,7 @@
       matchSourceUrls: ['https://github.com/ReactTraining/react-router', 'https://github.com/remix-run/react-router'],
       // Override the schedule to get immediate PRs.
       schedule: null,
+      minimumReleaseAge: null,
       // Apply a unique label so we can trigger additional workflows for these PRs.
       addLabels: ['bump-framework-in-fixtures'],
       // Bump even if the release isn't tagged as `latest`.


### PR DESCRIPTION
## Description

In the base Renovate config here we're now setting a `minimumReleaseAge`: https://github.com/netlify/renovate-config/pull/109.

In this repo however we have a very specific setup for Remix/RR7 framework bumps to provide immediate early warning of incompatibilities with new releases, including unstable releases. So, opt out of `minimumReleaseAge` just for those.

## Related Tickets & Documents

EX-2222