### PR TITLE
feat!: require vite 6+, node.js 22.22+

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22.13.0', '24']
+        node-version: ['22.22.0', '24']
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['22.13.0', '24']
+        node-version: ['22.22.0', '24']
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/vite-plugin-react-router/package.json
+++ b/packages/vite-plugin-react-router/package.json
@@ -75,10 +75,10 @@
   },
   "peerDependencies": {
     "react-router": ">=7.9.0",
-    "vite": ">=5.0.0"
+    "vite": ">=6.0.0"
   },
   "engines": {
-    "node": ">=20.6.1"
+    "node": ">=22.22.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

- Bump Vite peer dependency from 5+ to 6+. [Vite 5 is unsupported](https://vite.dev/releases#supported-versions).
- Bump Node.js supported range from 20.6.1+ to 22.22.0+. [Node.js 20 is unsupported](https://nodejs.org/en/about/previous-releases).

I believe this is the lowest we can go to support React Router 8 while retaining support for React Router 7.

Note: bumped lowest tested node.js version in CI already in https://github.com/netlify/remix-compute/pull/709.