### PR TITLE
feat!: publish ESM only, remove CJS build

### DIFF
--- a/packages/vite-plugin-react-router/package.json
+++ b/packages/vite-plugin-react-router/package.json
@@ -2,32 +2,25 @@
   "name": "@netlify/vite-plugin-react-router",
   "version": "3.1.1",
   "description": "React Router 7+ Vite plugin for Netlify",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./serverless": {
-      "types": "./dist/serverless.d.mts",
-      "default": "./dist/serverless.mjs"
+      "types": "./dist/serverless.d.ts",
+      "default": "./dist/serverless.js"
     },
     "./edge": {
-      "types": "./dist/edge.d.mts",
-      "default": "./dist/edge.mjs"
+      "types": "./dist/edge.d.ts",
+      "default": "./dist/edge.js"
     },
     "./entry.server.edge": {
-      "types": "./dist/entry.server.edge.d.mts",
-      "default": "./dist/entry.server.edge.mjs"
+      "types": "./dist/entry.server.edge.d.ts",
+      "default": "./dist/entry.server.edge.js"
     }
   },
   "files": [

--- a/packages/vite-plugin-react-router/tsup.config.ts
+++ b/packages/vite-plugin-react-router/tsup.config.ts
@@ -1,26 +1,16 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig([
-  {
-    entry: {
-      index: 'src/index.ts',
-      serverless: 'src/runtimes/netlify-functions.ts',
-      edge: 'src/runtimes/netlify-edge-functions.ts',
-      'entry.server.edge': 'src/entry.server.edge.tsx',
-    },
-    format: ['esm'],
-    dts: true,
-    target: 'node20',
-    // Can't use `clean: true` because of this bug: https://github.com/egoist/tsup/issues/670.
-    // TODO(serhalp): Switch to tsdown; tsup is no longer maintained anyway.
-    clean: false,
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    serverless: 'src/runtimes/netlify-functions.ts',
+    edge: 'src/runtimes/netlify-edge-functions.ts',
+    'entry.server.edge': 'src/entry.server.edge.tsx',
   },
-  // TODO(serhalp): Remove in a future major version.
-  {
-    entry: ['src/index.ts'],
-    format: ['cjs'],
-    dts: true,
-    target: 'node20',
-    clean: false,
-  },
-])
+  format: ['esm'],
+  dts: true,
+  target: 'node20',
+  // Can't use `clean: true` because of this bug: https://github.com/egoist/tsup/issues/670.
+  // TODO(serhalp): Switch to tsdown; tsup is no longer maintained anyway.
+  clean: false,
+})


### PR DESCRIPTION
## Description

`@netlify/vite-plugin-react-router` is now published as ESM only. This removes the CommonJS build.

It's time: https://antfu.me/posts/move-on-to-esm-only.

(Other packages in this monorepo are unchanged.)